### PR TITLE
fix(session-rename): handle SIGPIPE and array message content

### DIFF
--- a/bin/claude-session-rename
+++ b/bin/claude-session-rename
@@ -49,9 +49,11 @@ get_first_user_message() {
 
     # Extract first user message content (grep for type:user, then extract message content)
     # The session file is JSONL - each line is a JSON object
+    # Note: message.content can be a string OR an array (for messages with images)
+    # The || true prevents SIGPIPE (exit 141) when head closes pipe early with pipefail
     grep -m1 '"type":"user"' "$session_file" 2>/dev/null | \
-        jq -r '.message.content // empty' 2>/dev/null | \
-        head -c 2000
+        jq -r 'if .message.content | type == "array" then (.message.content[] | select(.type == "text") | .text) else .message.content // empty end' 2>/dev/null | \
+        head -c 2000 || true
 }
 
 # Generate a short name using Claude CLI


### PR DESCRIPTION
## Summary
- Fixes exit 141 (SIGPIPE) when processing sessions with large content (>2000 bytes from jq)
- Handles messages with images where `.message.content` is an array instead of string
- Adds 141 to SuccessExitStatus as a safety measure

## Root Cause
With `set -o pipefail`, when `jq` outputs more than 2000 bytes and `head -c 2000` closes the pipe early, jq receives SIGPIPE and exits with 141 (128 + 13).

## Changes
- Add `|| true` to the pipeline in `get_first_user_message()` to suppress SIGPIPE
- Fix jq expression to extract text from array content for messages with images
- Add exit code 141 to systemd SuccessExitStatus

## Test plan
- [x] Rebuild completed successfully
- [x] Service ran and renamed sessions
- [x] Dry-run with verbose mode shows no errors