### PR TITLE
feat(hooks): add wrapper script for graceful hook failures

### DIFF
--- a/agents/hooks/run-hook.sh
+++ b/agents/hooks/run-hook.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Hook wrapper - runs hooks gracefully, failing without blocking Claude
+# Exit codes: 0=success, 1=non-blocking failure (continues), 2=blocking (stops tool)
+
+HOOK_SCRIPT="$1"
+shift
+
+if [[ -z "$HOOK_SCRIPT" ]]; then
+    echo "Usage: run-hook.sh <hook-script> [args...]" >&2
+    exit 1
+fi
+
+if [[ ! -f "$HOOK_SCRIPT" ]]; then
+    exit 1
+fi
+
+python3 "$HOOK_SCRIPT" "$@"
+exit_code=$?
+
+# Convert blocking exit code 2 from missing/broken hooks to non-blocking
+# Only real hook logic should use exit 2 intentionally
+if [[ $exit_code -eq 2 && ! -f "$HOOK_SCRIPT" ]]; then
+    exit 1
+fi
+
+exit $exit_code

--- a/agents/hooks/run-hook.sh
+++ b/agents/hooks/run-hook.sh
@@ -15,12 +15,3 @@ if [[ ! -f "$HOOK_SCRIPT" ]]; then
 fi
 
 python3 "$HOOK_SCRIPT" "$@"
-exit_code=$?
-
-# Convert blocking exit code 2 from missing/broken hooks to non-blocking
-# Only real hook logic should use exit 2 intentionally
-if [[ $exit_code -eq 2 && ! -f "$HOOK_SCRIPT" ]]; then
-    exit 1
-fi
-
-exit $exit_code

--- a/home/modules/claude/config.nix
+++ b/home/modules/claude/config.nix
@@ -22,6 +22,7 @@
       respectGitignore = true;
     };
     enabledPlugins = {
+      "claude-stt@jarrodwatts-claude-stt" = true;
       "typescript-lsp@claude-plugins-official" = true;
       "jdtls-lsp@claude-plugins-official" = true;
       # NOTE: some lsps are installed via pkgs in lsp.nix

--- a/home/modules/claude/config.nix
+++ b/home/modules/claude/config.nix
@@ -22,7 +22,6 @@
       respectGitignore = true;
     };
     enabledPlugins = {
-      "claude-stt@jarrodwatts-claude-stt" = true;
       "typescript-lsp@claude-plugins-official" = true;
       "jdtls-lsp@claude-plugins-official" = true;
       # NOTE: some lsps are installed via pkgs in lsp.nix

--- a/home/modules/claude/config.nix
+++ b/home/modules/claude/config.nix
@@ -1,5 +1,6 @@
 {pkgs, ...}: let
   hooksPath = "~/.claude/hooks";
+  runHook = "${hooksPath}/run-hook.sh";
 
   claudeGlobalSettings = {
     installMethod = "native";
@@ -35,7 +36,7 @@
           hooks = [
             {
               type = "command";
-              command = "python3 ${hooksPath}/session-context.py";
+              command = "${runHook} ${hooksPath}/session-context.py";
               timeout = 5000;
             }
           ];
@@ -50,39 +51,44 @@
             # Tmux and timing
             {
               type = "command";
-              command = "python3 ${hooksPath}/tmux-reminder.py";
+              command = "${runHook} ${hooksPath}/tmux-reminder.py";
               timeout = 3000;
             }
             {
               type = "command";
-              command = "python3 ${hooksPath}/command-timing.py";
+              command = "${runHook} ${hooksPath}/command-timing.py";
               timeout = 2000;
             }
             # Safety checks
             {
               type = "command";
-              command = "python3 ${hooksPath}/dangerous-command-guard.py";
+              command = "${runHook} ${hooksPath}/dangerous-command-guard.py";
               timeout = 3000;
             }
             # Git workflow
             {
               type = "command";
-              command = "python3 ${hooksPath}/git-reminder.py";
+              command = "${runHook} ${hooksPath}/git-reminder.py";
               timeout = 5000;
             }
             {
               type = "command";
-              command = "python3 ${hooksPath}/branch-protection.py";
+              command = "${runHook} ${hooksPath}/branch-protection.py";
               timeout = 5000;
             }
             {
               type = "command";
-              command = "python3 ${hooksPath}/worktree-reminder.py";
+              command = "${runHook} ${hooksPath}/worktree-reminder.py";
               timeout = 5000;
             }
             {
               type = "command";
-              command = "python3 ${hooksPath}/delegation-reminder.py";
+              command = "${runHook} ${hooksPath}/test-before-commit.py";
+              timeout = 5000;
+            }
+            {
+              type = "command";
+              command = "${runHook} ${hooksPath}/delegation-reminder.py";
               timeout = 5000;
             }
           ];
@@ -92,7 +98,7 @@
           hooks = [
             {
               type = "command";
-              command = "python3 ${hooksPath}/sensitive-file-guard.py";
+              command = "${runHook} ${hooksPath}/sensitive-file-guard.py";
               timeout = 3000;
             }
           ];
@@ -102,7 +108,7 @@
           hooks = [
             {
               type = "command";
-              command = "python3 ${hooksPath}/subagent-context-reminder.py";
+              command = "${runHook} ${hooksPath}/subagent-context-reminder.py";
               timeout = 3000;
             }
           ];
@@ -116,7 +122,7 @@
           hooks = [
             {
               type = "command";
-              command = "python3 ${hooksPath}/command-timing.py";
+              command = "${runHook} ${hooksPath}/command-timing.py";
               timeout = 2000;
             }
           ];
@@ -126,17 +132,17 @@
           hooks = [
             {
               type = "command";
-              command = "python3 ${hooksPath}/nix-rebuild-reminder.py";
+              command = "${runHook} ${hooksPath}/nix-rebuild-reminder.py";
               timeout = 3000;
             }
             {
               type = "command";
-              command = "python3 ${hooksPath}/auto-format.py";
+              command = "${runHook} ${hooksPath}/auto-format.py";
               timeout = 15000;
             }
             {
               type = "command";
-              command = "python3 ${hooksPath}/lint-on-edit.py";
+              command = "${runHook} ${hooksPath}/lint-on-edit.py";
               timeout = 30000;
             }
           ];
@@ -150,7 +156,7 @@
           hooks = [
             {
               type = "command";
-              command = "python3 ${hooksPath}/delegation-reminder.py";
+              command = "${runHook} ${hooksPath}/delegation-reminder.py";
               timeout = 3000;
             }
           ];

--- a/home/modules/claude/hooks.nix
+++ b/home/modules/claude/hooks.nix
@@ -13,6 +13,7 @@
       name = ".claude/hooks/${filename}";
       value = {
         source = hooksDir + "/${filename}";
+        executable = lib.hasSuffix ".sh" filename;
       };
     })
     hookFiles);

--- a/home/modules/claude/hooks.nix
+++ b/home/modules/claude/hooks.nix
@@ -1,10 +1,10 @@
-{ lib, ... }:
-let
+{lib, ...}: let
   hooksDir = ../../../agents/hooks;
 
-  # Get all Python hook scripts from the hooks directory
-  hookFiles = builtins.filter
-    (name: lib.hasSuffix ".py" name)
+  # Get all hook scripts from the hooks directory (.py and .sh)
+  hookFiles =
+    builtins.filter
+    (name: lib.hasSuffix ".py" name || lib.hasSuffix ".sh" name)
     (builtins.attrNames (builtins.readDir hooksDir));
 
   # Create home.file entries for each hook script
@@ -26,7 +26,6 @@ let
       text = "";
     };
   };
-in
-{
+in {
   home.file = hookSymlinks // markerFile;
 }


### PR DESCRIPTION
## Summary
- Add `run-hook.sh` wrapper script that checks hook existence before execution
- Update all hook commands to use the wrapper
- Return exit code 1 (non-blocking) if hook file is missing

## Problem
When running multiple Claude Code sessions, hooks can be added/removed between sessions. Stale sessions have cached hook configurations that reference files that no longer exist, causing blocking errors on every tool call.

## Solution
The wrapper script provides graceful degradation:
- If hook file exists → run it normally
- If hook file missing → exit 1 (non-blocking, continues execution)

This ensures hooks fail gracefully without breaking Claude sessions.

## Test plan
- [x] Build passes
- [x] Hooks directory includes run-hook.sh
- [x] settings.json uses wrapper for all hooks
- [x] Bash commands execute without hook errors