### PR TITLE
feat: integrate omarchy-nix for Hyprland configuration

### DIFF
--- a/.config/wezterm/wezterm.lua
+++ b/.config/wezterm/wezterm.lua
@@ -69,14 +69,6 @@ wezterm.on('gui-startup', function(cmd)
   window:gui_window():maximize()
 end)
 
--- Maximize window when GUI attaches (handles cases where gui-startup doesn't fire)
-wezterm.on('gui-attached', function(domain)
-  local window = mux.get_active_window()
-  if window then
-    window:gui_window():maximize()
-  end
-end)
-
 return {
   font = wezterm.font_with_fallback({
     { family = 'FiraCode Nerd Font Mono', weight = 'Regular' },

--- a/agents/subagent/dotfiles-expert.md
+++ b/agents/subagent/dotfiles-expert.md
@@ -77,16 +77,9 @@ Stage files first - nix reads git index, not working tree.
 </rebuild_decision>
 
 <rebuild_execution>
-Detect context: grep -q '^ID=nixos' /etc/os-release
-
-Always dry-run first:
-Home-manager: home-manager build --flake ~/.dotfiles#lucas.zanoni@x86_64-linux
-NixOS: nixos-rebuild dry-run --flake ~/.dotfiles#zanoni
-
-If dry-run fails: fix errors before actual rebuild.
-
-Home-manager: execute directly (no sudo): home-manager switch --flake ... -b "backup-$(date +%Y-%m-%d-%H-%M-%S)"
-NixOS: return to user with instruction "Run: ./bin/rebuild" - do NOT attempt sudo.
+Detect context of the system you are rebuilding, NixOs, Ubuntu, etc. Understand .bin/rebuild script that is the default command. Always dry-run first to make sure flake is correct.
+On Home-manager standalone systems, execute directly (no sudo) the rebuild command.
+On NixOS ask the user to run the rebuild and after that continue with the testing.
 </rebuild_execution>
 
 <git_workflow>

--- a/agents/subagent/dotfiles-expert.md
+++ b/agents/subagent/dotfiles-expert.md
@@ -78,6 +78,7 @@ Stage files first - nix reads git index, not working tree.
 
 <rebuild_execution>
 Detect context of the system you are rebuilding, NixOs, Ubuntu, etc. Understand .bin/rebuild script that is the default command. Always dry-run first to make sure flake is correct.
+NixOS: "cd ~/.dotfiles && nix build .#nixosConfigurations.zanoni.config.system.build.toplevel --dry-run"
 On Home-manager standalone systems, execute directly (no sudo) the rebuild command.
 On NixOS ask the user to run the rebuild and after that continue with the testing.
 </rebuild_execution>
@@ -89,7 +90,7 @@ Nix rebuilds read from git index. Unstaged files invisible during rebuild. After
 <package_channels>
 pkgs: stable (check flake.nix for version)
 unstable: nixos-unstable
-latest: same as unstable, updated with nix flake update nixpkgs-latest
+latest: same as unstable, updated with nix flake update nixpkgs-latest but done daily.
 </package_channels>
 
 <anti_patterns>

--- a/flake.lock
+++ b/flake.lock
@@ -21,6 +21,59 @@
         "type": "github"
       }
     },
+    "aquamarine": {
+      "inputs": {
+        "hyprutils": [
+          "omarchy-nix",
+          "hyprland",
+          "hyprutils"
+        ],
+        "hyprwayland-scanner": [
+          "omarchy-nix",
+          "hyprland",
+          "hyprwayland-scanner"
+        ],
+        "nixpkgs": [
+          "omarchy-nix",
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "omarchy-nix",
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1753216019,
+        "narHash": "sha256-zik7WISrR1ks2l6T1MZqZHb/OqroHdJnSnAehkE0kCk=",
+        "owner": "hyprwm",
+        "repo": "aquamarine",
+        "rev": "be166e11d86ba4186db93e10c54a141058bdce49",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "aquamarine",
+        "type": "github"
+      }
+    },
+    "base16-schemes": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696158499,
+        "narHash": "sha256-5yIHgDTPjoX/3oDEfLSQ0eJZdFL1SaCfb9d6M0RmOTM=",
+        "owner": "tinted-theming",
+        "repo": "base16-schemes",
+        "rev": "a9112eaae86d9dd8ee6bb9445b664fba2f94037a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "base16-schemes",
+        "type": "github"
+      }
+    },
     "cachix": {
       "inputs": {
         "devenv": [
@@ -169,6 +222,22 @@
       }
     },
     "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
       "locked": {
         "lastModified": 1761588595,
         "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
@@ -278,7 +347,7 @@
     },
     "flake-utils_5": {
       "inputs": {
-        "systems": "systems_6"
+        "systems": "systems_7"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -296,7 +365,7 @@
     },
     "flake-utils_6": {
       "inputs": {
-        "systems": "systems_7"
+        "systems": "systems_8"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -360,6 +429,29 @@
         "type": "github"
       }
     },
+    "gitignore_2": {
+      "inputs": {
+        "nixpkgs": [
+          "omarchy-nix",
+          "hyprland",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -399,6 +491,308 @@
         "owner": "nix-community",
         "ref": "release-25.11",
         "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager_3": {
+      "inputs": {
+        "nixpkgs": [
+          "omarchy-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1755229570,
+        "narHash": "sha256-soZegto0xXzG2zYlu/zjknDHv0Z7tRS5EQs+Z/VRTBg=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "11626a4383b458f8dc5ea3237eaa04e8ab1912f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "hyprcursor": {
+      "inputs": {
+        "hyprlang": [
+          "omarchy-nix",
+          "hyprland",
+          "hyprlang"
+        ],
+        "nixpkgs": [
+          "omarchy-nix",
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "omarchy-nix",
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1753964049,
+        "narHash": "sha256-lIqabfBY7z/OANxHoPeIrDJrFyYy9jAM4GQLzZ2feCM=",
+        "owner": "hyprwm",
+        "repo": "hyprcursor",
+        "rev": "44e91d467bdad8dcf8bbd2ac7cf49972540980a5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprcursor",
+        "type": "github"
+      }
+    },
+    "hyprgraphics": {
+      "inputs": {
+        "hyprutils": [
+          "omarchy-nix",
+          "hyprland",
+          "hyprutils"
+        ],
+        "nixpkgs": [
+          "omarchy-nix",
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "omarchy-nix",
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1754305013,
+        "narHash": "sha256-u+M2f0Xf1lVHzIPQ7DsNCDkM1NYxykOSsRr4t3TbSM4=",
+        "owner": "hyprwm",
+        "repo": "hyprgraphics",
+        "rev": "4c1d63a0f22135db123fc789f174b89544c6ec2d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprgraphics",
+        "type": "github"
+      }
+    },
+    "hyprland": {
+      "inputs": {
+        "aquamarine": "aquamarine",
+        "hyprcursor": "hyprcursor",
+        "hyprgraphics": "hyprgraphics",
+        "hyprland-protocols": "hyprland-protocols",
+        "hyprland-qtutils": "hyprland-qtutils",
+        "hyprlang": "hyprlang",
+        "hyprutils": "hyprutils",
+        "hyprwayland-scanner": "hyprwayland-scanner",
+        "nixpkgs": "nixpkgs_8",
+        "pre-commit-hooks": "pre-commit-hooks",
+        "systems": "systems_6",
+        "xdph": "xdph"
+      },
+      "locked": {
+        "lastModified": 1755184403,
+        "narHash": "sha256-VI+ZPD/uIFjzYW8IcyvBgvwyDIvUe4/xh/kOHTbITX8=",
+        "owner": "hyprwm",
+        "repo": "Hyprland",
+        "rev": "60d769a89908c29e19100059985db15a7b6bab6a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "Hyprland",
+        "type": "github"
+      }
+    },
+    "hyprland-protocols": {
+      "inputs": {
+        "nixpkgs": [
+          "omarchy-nix",
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "omarchy-nix",
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1749046714,
+        "narHash": "sha256-kymV5FMnddYGI+UjwIw8ceDjdeg7ToDVjbHCvUlhn14=",
+        "owner": "hyprwm",
+        "repo": "hyprland-protocols",
+        "rev": "613878cb6f459c5e323aaafe1e6f388ac8a36330",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprland-protocols",
+        "type": "github"
+      }
+    },
+    "hyprland-qt-support": {
+      "inputs": {
+        "hyprlang": [
+          "omarchy-nix",
+          "hyprland",
+          "hyprland-qtutils",
+          "hyprlang"
+        ],
+        "nixpkgs": [
+          "omarchy-nix",
+          "hyprland",
+          "hyprland-qtutils",
+          "nixpkgs"
+        ],
+        "systems": [
+          "omarchy-nix",
+          "hyprland",
+          "hyprland-qtutils",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1749154592,
+        "narHash": "sha256-DO7z5CeT/ddSGDEnK9mAXm1qlGL47L3VAHLlLXoCjhE=",
+        "owner": "hyprwm",
+        "repo": "hyprland-qt-support",
+        "rev": "4c8053c3c888138a30c3a6c45c2e45f5484f2074",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprland-qt-support",
+        "type": "github"
+      }
+    },
+    "hyprland-qtutils": {
+      "inputs": {
+        "hyprland-qt-support": "hyprland-qt-support",
+        "hyprlang": [
+          "omarchy-nix",
+          "hyprland",
+          "hyprlang"
+        ],
+        "hyprutils": [
+          "omarchy-nix",
+          "hyprland",
+          "hyprland-qtutils",
+          "hyprlang",
+          "hyprutils"
+        ],
+        "nixpkgs": [
+          "omarchy-nix",
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "omarchy-nix",
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1753819801,
+        "narHash": "sha256-tHe6XeNeVeKapkNM3tcjW4RuD+tB2iwwoogWJOtsqTI=",
+        "owner": "hyprwm",
+        "repo": "hyprland-qtutils",
+        "rev": "b308a818b9dcaa7ab8ccab891c1b84ebde2152bc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprland-qtutils",
+        "type": "github"
+      }
+    },
+    "hyprlang": {
+      "inputs": {
+        "hyprutils": [
+          "omarchy-nix",
+          "hyprland",
+          "hyprutils"
+        ],
+        "nixpkgs": [
+          "omarchy-nix",
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "omarchy-nix",
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1753622892,
+        "narHash": "sha256-0K+A+gmOI8IklSg5It1nyRNv0kCNL51duwnhUO/B8JA=",
+        "owner": "hyprwm",
+        "repo": "hyprlang",
+        "rev": "23f0debd2003f17bd65f851cd3f930cff8a8c809",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprlang",
+        "type": "github"
+      }
+    },
+    "hyprutils": {
+      "inputs": {
+        "nixpkgs": [
+          "omarchy-nix",
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "omarchy-nix",
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1754481650,
+        "narHash": "sha256-6u6HdEFJh5gY6VfyMQbhP7zDdVcqOrCDTkbiHJmAtMI=",
+        "owner": "hyprwm",
+        "repo": "hyprutils",
+        "rev": "df6b8820c4a0835d83d0c7c7be86fbc555f1f7fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprutils",
+        "type": "github"
+      }
+    },
+    "hyprwayland-scanner": {
+      "inputs": {
+        "nixpkgs": [
+          "omarchy-nix",
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "omarchy-nix",
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1751897909,
+        "narHash": "sha256-FnhBENxihITZldThvbO7883PdXC/2dzW4eiNvtoV5Ao=",
+        "owner": "hyprwm",
+        "repo": "hyprwayland-scanner",
+        "rev": "fcca0c61f988a9d092cbb33e906775014c61579d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprwayland-scanner",
         "type": "github"
       }
     },
@@ -461,6 +855,25 @@
         "type": "github"
       }
     },
+    "nix-colors": {
+      "inputs": {
+        "base16-schemes": "base16-schemes",
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1707825078,
+        "narHash": "sha256-hTfge2J2W+42SZ7VHXkf4kjU+qzFqPeC9k66jAUBMHk=",
+        "owner": "misterio77",
+        "repo": "nix-colors",
+        "rev": "b01f024090d2c4fc3152cd0cf12027a7b8453ba1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "misterio77",
+        "repo": "nix-colors",
+        "type": "github"
+      }
+    },
     "nixgl": {
       "inputs": {
         "flake-utils": "flake-utils_4",
@@ -512,6 +925,21 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1697935651,
+        "narHash": "sha256-qOfWjQ2JQSQL15KLh6D7xQhx0qgZlYZTYlcEiRuAMMw=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e1e11fdbb01113d85c7f41cada9d2847660e3902",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1760038930,
@@ -530,6 +958,38 @@
     },
     "nixpkgs_10": {
       "locked": {
+        "lastModified": 1767364772,
+        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_11": {
+      "locked": {
+        "lastModified": 1755704039,
+        "narHash": "sha256-gKlP0LbyJ3qX0KObfIWcp5nbuHSb5EHwIvU6UcNBg2A=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9cb344e96d5b6918e94e1bca2d9f3ea1e9615545",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_12": {
+      "locked": {
         "lastModified": 1720535198,
         "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
         "owner": "NixOS",
@@ -544,7 +1004,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_11": {
+    "nixpkgs_13": {
       "locked": {
         "lastModified": 1762844143,
         "narHash": "sha256-SlybxLZ1/e4T2lb1czEtWVzDCVSTvk9WLwGhmxFmBxI=",
@@ -560,7 +1020,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_12": {
+    "nixpkgs_14": {
       "locked": {
         "lastModified": 1767767207,
         "narHash": "sha256-Mj3d3PfwltLmukFal5i3fFt27L6NiKXdBezC1EBuZs4=",
@@ -576,7 +1036,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_13": {
+    "nixpkgs_15": {
       "locked": {
         "lastModified": 315532800,
         "narHash": "sha256-5CwQ80ucRHiqVbMEEbTFnjz70/axSJ0aliyzSaFSkmY=",
@@ -686,39 +1146,60 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1767364772,
-        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
+        "lastModified": 1754725699,
+        "narHash": "sha256-iAcj9T/Y+3DBy2J0N+yF9XQQQ8IEb5swLFzs23CdP88=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
+        "rev": "85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1755704039,
-        "narHash": "sha256-gKlP0LbyJ3qX0KObfIWcp5nbuHSb5EHwIvU6UcNBg2A=",
+        "lastModified": 1755186698,
+        "narHash": "sha256-wNO3+Ks2jZJ4nTHMuks+cxAiVBGNuEBXsT29Bz6HASo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9cb344e96d5b6918e94e1bca2d9f3ea1e9615545",
+        "rev": "fbcf476f790d8a217c3eab4e12033dc4a0f6d23c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "omarchy-nix": {
+      "inputs": {
+        "home-manager": "home-manager_3",
+        "hyprland": "hyprland",
+        "nix-colors": "nix-colors",
+        "nixpkgs": "nixpkgs_9"
+      },
+      "locked": {
+        "lastModified": 1762999930,
+        "narHash": "sha256-uKyxLwiN6sD6EmRSno66y1a8oqISr1XiWxbWHoMJT7I=",
+        "owner": "henrysipp",
+        "repo": "omarchy-nix",
+        "rev": "308e0f85a0deb820c01cfbe1b4faee1daab4da12",
+        "type": "github"
+      },
+      "original": {
+        "owner": "henrysipp",
+        "repo": "omarchy-nix",
         "type": "github"
       }
     },
     "opencode": {
       "inputs": {
-        "nixpkgs": "nixpkgs_8"
+        "nixpkgs": "nixpkgs_10"
       },
       "locked": {
         "lastModified": 1767803912,
@@ -735,9 +1216,33 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "gitignore": "gitignore_2",
+        "nixpkgs": [
+          "omarchy-nix",
+          "hyprland",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1754416808,
+        "narHash": "sha256-c6yg0EQ9xVESx6HGDOCMcyRSjaTpNJP10ef+6fRcofA=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "9c52372878df6911f9afc1e2a1391f55e4dfc864",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "readItNow-rc": {
       "inputs": {
-        "nixpkgs": "nixpkgs_9"
+        "nixpkgs": "nixpkgs_11"
       },
       "locked": {
         "lastModified": 1757707883,
@@ -766,6 +1271,7 @@
         "nixpkgs": "nixpkgs_7",
         "nixpkgs-latest": "nixpkgs-latest",
         "nixpkgs-unstable": "nixpkgs-unstable",
+        "omarchy-nix": "omarchy-nix",
         "opencode": "opencode",
         "readItNow-rc": "readItNow-rc",
         "tui-notifier": "tui-notifier",
@@ -872,16 +1378,16 @@
     },
     "systems_6": {
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
         "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "default",
+        "repo": "default-linux",
         "type": "github"
       }
     },
@@ -900,9 +1406,24 @@
         "type": "github"
       }
     },
+    "systems_8": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "tui-notifier": {
       "inputs": {
-        "nixpkgs": "nixpkgs_10"
+        "nixpkgs": "nixpkgs_12"
       },
       "locked": {
         "lastModified": 1755004924,
@@ -922,7 +1443,7 @@
     "tuisvn": {
       "inputs": {
         "flake-utils": "flake-utils_5",
-        "nixpkgs": "nixpkgs_11"
+        "nixpkgs": "nixpkgs_13"
       },
       "locked": {
         "lastModified": 1762953472,
@@ -941,7 +1462,7 @@
     "voxtype": {
       "inputs": {
         "flake-utils": "flake-utils_6",
-        "nixpkgs": "nixpkgs_12"
+        "nixpkgs": "nixpkgs_14"
       },
       "locked": {
         "lastModified": 1768181250,
@@ -957,11 +1478,58 @@
         "type": "github"
       }
     },
+    "xdph": {
+      "inputs": {
+        "hyprland-protocols": [
+          "omarchy-nix",
+          "hyprland",
+          "hyprland-protocols"
+        ],
+        "hyprlang": [
+          "omarchy-nix",
+          "hyprland",
+          "hyprlang"
+        ],
+        "hyprutils": [
+          "omarchy-nix",
+          "hyprland",
+          "hyprutils"
+        ],
+        "hyprwayland-scanner": [
+          "omarchy-nix",
+          "hyprland",
+          "hyprwayland-scanner"
+        ],
+        "nixpkgs": [
+          "omarchy-nix",
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "omarchy-nix",
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1753633878,
+        "narHash": "sha256-js2sLRtsOUA/aT10OCDaTjO80yplqwOIaLUqEe0nMx0=",
+        "owner": "hyprwm",
+        "repo": "xdg-desktop-portal-hyprland",
+        "rev": "371b96bd11ad2006ed4f21229dbd1be69bed3e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "xdg-desktop-portal-hyprland",
+        "type": "github"
+      }
+    },
     "zed-editor": {
       "inputs": {
         "crane": "crane",
-        "flake-compat": "flake-compat_2",
-        "nixpkgs": "nixpkgs_13",
+        "flake-compat": "flake-compat_3",
+        "nixpkgs": "nixpkgs_15",
         "rust-overlay": "rust-overlay"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -111,6 +111,7 @@
             modules = [
               ./hosts/dellg15
               ./users/${username}/nixos.nix
+              ./nixos/modules/omarchy # Provides osConfig.omarchy for home-manager
               home-manager.nixosModules.home-manager
               (import ./users/${username}/nixos-home-config.nix)
             ];

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
     zed-editor.url = "github:zed-industries/zed/v0.218.5";
     devenv.url = "github:cachix/devenv/v1.9.2";
     # Branch/default (actively maintained)
+    omarchy-nix.url = "github:henrysipp/omarchy-nix";
     cbonsai.url = "github:castrozan/cbonsai";
     cmatrix.url = "github:castrozan/cmatrix";
     tuisvn.url = "github:castrozan/tuisvn";

--- a/home/modules/gnome/dconf.nix
+++ b/home/modules/gnome/dconf.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ lib, ... }:
 let
   wezterm-quick-temp-shell-command = "wezterm start -- tmux new-session";
 in
@@ -15,7 +15,7 @@ in
       enable-hot-corners = true;
       clock-show-weekday = true;
       clock-show-seconds = true;
-      gtk-theme = "Yaru-viridian-dark";
+      gtk-theme = lib.mkForce "Yaru-viridian-dark";
       icon-theme = "Yaru-viridian";
       color-scheme = "prefer-dark";
       cursor-theme = "Adwaita";

--- a/home/modules/omarchy/default.nix
+++ b/home/modules/omarchy/default.nix
@@ -22,14 +22,15 @@ in
 
     # Exclude packages we already have configured elsewhere
     exclude_packages = with pkgs; [
-      ghostty # Using kitty instead
+      ghostty # Using wezterm instead
+      kitty # Using wezterm instead
       chromium # Using brave instead
     ];
   };
 
   # Override default applications to use our preferred apps
   wayland.windowManager.hyprland.settings = {
-    "$terminal" = lib.mkForce "kitty";
+    "$terminal" = lib.mkForce "wezterm";
     "$browser" = lib.mkForce "brave";
     "$fileManager" = lib.mkForce "nautilus --new-window";
 

--- a/home/modules/omarchy/default.nix
+++ b/home/modules/omarchy/default.nix
@@ -14,18 +14,21 @@ in
   ];
 
   omarchy = {
-    full_name = "Lucas Zanoni";
-    email_address = "lucas@zanoni.dev";
-    theme = "catppuccin";
-    scale = 1;
-    monitors = [ "HDMI-A-1" ];
+    full_name = lib.mkForce "Lucas Zanoni";
+    email_address = lib.mkForce "lucas@zanoni.dev";
+    theme = lib.mkForce "tokyo-night"; # catppuccin-macchiato is incomplete in omarchy-nix
+    scale = lib.mkForce 1;
+    monitors = lib.mkForce [ "HDMI-A-1" ];
 
     # Exclude packages we already have configured elsewhere
-    exclude_packages = with pkgs; [
-      ghostty # Using wezterm instead
-      kitty # Using wezterm instead
-      chromium # Using brave instead
-    ];
+    exclude_packages = lib.mkForce (
+      with pkgs;
+      [
+        ghostty # Using wezterm instead
+        kitty # Using wezterm instead
+        chromium # Using brave instead
+      ]
+    );
   };
 
   # Override default applications to use our preferred apps

--- a/home/modules/omarchy/default.nix
+++ b/home/modules/omarchy/default.nix
@@ -1,0 +1,41 @@
+{
+  config,
+  pkgs,
+  lib,
+  inputs,
+  ...
+}:
+let
+  system = pkgs.stdenv.hostPlatform.system;
+in
+{
+  imports = [
+    inputs.omarchy-nix.homeManagerModules.default
+  ];
+
+  omarchy = {
+    full_name = "Lucas Zanoni";
+    email_address = "lucas@zanoni.dev";
+    theme = "catppuccin";
+    scale = 1;
+    monitors = [ "HDMI-A-1" ];
+
+    # Exclude packages we already have configured elsewhere
+    exclude_packages = with pkgs; [
+      ghostty # Using kitty instead
+      chromium # Using brave instead
+    ];
+  };
+
+  # Override default applications to use our preferred apps
+  wayland.windowManager.hyprland.settings = {
+    "$terminal" = lib.mkForce "kitty";
+    "$browser" = lib.mkForce "brave";
+    "$fileManager" = lib.mkForce "nautilus --new-window";
+
+    # Lower mouse sensitivity (current is 0, going to -0.3)
+    input = {
+      sensitivity = lib.mkForce (-0.3);
+    };
+  };
+}

--- a/home/modules/omarchy/default.nix
+++ b/home/modules/omarchy/default.nix
@@ -38,5 +38,23 @@ in
     input = {
       sensitivity = lib.mkForce (-0.3);
     };
+
+    # Override autostart - remove commands that require packages not installed
+    # (omarchy-nix expects nixosModule to be imported for these packages)
+    exec-once = lib.mkForce [
+      "mako" # notifications
+      "clipse -listen" # clipboard (without wl-clip-persist)
+    ];
+
+    exec = lib.mkForce [
+      "pkill -SIGUSR2 waybar || waybar"
+    ];
   };
+
+  # Add packages that omarchy autostart needs but aren't in homeManagerModule
+  home.packages = with pkgs; [
+    mako # notification daemon
+    clipse # clipboard manager
+    wl-clipboard # clipboard tools
+  ];
 }

--- a/home/modules/omarchy/default.nix
+++ b/home/modules/omarchy/default.nix
@@ -49,6 +49,11 @@ in
     exec = lib.mkForce [
       "pkill -SIGUSR2 waybar || waybar"
     ];
+
+    # Override clipse keybinding to use wezterm instead of ghostty
+    bind = lib.mkAfter [
+      "CTRL SUPER, V, exec, wezterm start --class clipse -e clipse"
+    ];
   };
 
   # Add packages that omarchy autostart needs but aren't in homeManagerModule
@@ -56,5 +61,144 @@ in
     mako # notification daemon
     clipse # clipboard manager
     wl-clipboard # clipboard tools
+  ];
+
+  # Override waybar on-click commands that use ghostty
+  programs.waybar.settings = lib.mkForce [
+    {
+      layer = "top";
+      position = "top";
+      spacing = 0;
+      height = 26;
+      modules-left = [ "hyprland/workspaces" ];
+      modules-center = [ "clock" ];
+      modules-right = [
+        "tray"
+        "bluetooth"
+        "network"
+        "wireplumber"
+        "cpu"
+        "power-profiles-daemon"
+        "battery"
+      ];
+      "hyprland/workspaces" = {
+        on-click = "activate";
+        format = "{icon}";
+        format-icons = {
+          default = "";
+          "1" = "1";
+          "2" = "2";
+          "3" = "3";
+          "4" = "4";
+          "5" = "5";
+          active = "󱓻";
+        };
+        persistent-workspaces = {
+          "1" = [ ];
+          "2" = [ ];
+          "3" = [ ];
+          "4" = [ ];
+          "5" = [ ];
+        };
+      };
+      cpu = {
+        interval = 5;
+        format = "󰍛";
+        on-click = "wezterm -e btop"; # Changed from ghostty
+      };
+      clock = {
+        format = "{:%A %I:%M %p}";
+        format-alt = "{:%d %B W%V %Y}";
+        tooltip = false;
+      };
+      network = {
+        format-icons = [
+          "󰤯"
+          "󰤟"
+          "󰤢"
+          "󰤥"
+          "󰤨"
+        ];
+        format = "{icon}";
+        format-wifi = "{icon}";
+        format-ethernet = "󰀂";
+        format-disconnected = "󰖪";
+        tooltip-format-wifi = "{essid} ({frequency} GHz)\n⇣{bandwidthDownBytes}  ⇡{bandwidthUpBytes}";
+        tooltip-format-ethernet = "⇣{bandwidthDownBytes}  ⇡{bandwidthUpBytes}";
+        tooltip-format-disconnected = "Disconnected";
+        interval = 3;
+        nospacing = 1;
+        on-click = "wezterm -e nmtui"; # Changed from ghostty -e nmcli
+      };
+      battery = {
+        interval = 5;
+        format = "{capacity}% {icon}";
+        format-discharging = "{icon}";
+        format-charging = "{icon}";
+        format-plugged = "";
+        format-icons = {
+          charging = [
+            "󰢜"
+            "󰂆"
+            "󰂇"
+            "󰂈"
+            "󰢝"
+            "󰂉"
+            "󰢞"
+            "󰂊"
+            "󰂋"
+            "󰂅"
+          ];
+          default = [
+            "󰁺"
+            "󰁻"
+            "󰁼"
+            "󰁽"
+            "󰁾"
+            "󰁿"
+            "󰂀"
+            "󰂁"
+            "󰂂"
+            "󰁹"
+          ];
+        };
+        format-full = "Charged ";
+        tooltip-format-discharging = "{power:>1.0f}W↓ {capacity}%";
+        tooltip-format-charging = "{power:>1.0f}W↑ {capacity}%";
+        states = {
+          warning = 20;
+          critical = 10;
+        };
+      };
+      bluetooth = {
+        format = "󰂯";
+        format-disabled = "󰂲";
+        format-connected = "";
+        tooltip-format = "Devices connected: {num_connections}";
+        on-click = "blueberry";
+      };
+      wireplumber = {
+        format = "";
+        format-muted = "󰝟";
+        scroll-step = 5;
+        on-click = "pavucontrol";
+        tooltip-format = "Playing at {volume}%";
+        on-click-right = "wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle";
+        max-volume = 150;
+      };
+      tray = {
+        spacing = 13;
+      };
+      power-profiles-daemon = {
+        format = "{icon}";
+        tooltip-format = "Power profile: {profile}";
+        tooltip = true;
+        format-icons = {
+          power-saver = "󰡳";
+          balanced = "󰊚";
+          performance = "󰡴";
+        };
+      };
+    }
   ];
 }

--- a/home/modules/omarchy/default.nix
+++ b/home/modules/omarchy/default.nix
@@ -5,9 +5,6 @@
   inputs,
   ...
 }:
-let
-  system = pkgs.stdenv.hostPlatform.system;
-in
 {
   imports = [
     inputs.omarchy-nix.homeManagerModules.default

--- a/home/modules/omarchy/default.nix
+++ b/home/modules/omarchy/default.nix
@@ -64,6 +64,7 @@ in
     mako # notification daemon
     clipse # clipboard manager
     wl-clipboard # clipboard tools
+    blueberry # bluetooth manager for waybar click handler
   ];
 
   # Override waybar on-click commands that use ghostty

--- a/nixos/modules/omarchy/default.nix
+++ b/nixos/modules/omarchy/default.nix
@@ -74,10 +74,6 @@
     };
   };
 
-  # Provide default values for the options
-  # These will be overridden by the home-manager module's omarchy config
-  config.omarchy = {
-    full_name = lib.mkDefault "User";
-    email_address = lib.mkDefault "user@example.com";
-  };
+  # Don't set any config values here - let the home-manager module handle them.
+  # The NixOS module only provides the option definitions.
 }

--- a/nixos/modules/omarchy/default.nix
+++ b/nixos/modules/omarchy/default.nix
@@ -1,0 +1,83 @@
+# Minimal omarchy NixOS module
+# This only defines the omarchy options required by omarchy-nix's homeManagerModule
+# without bringing in the full system configuration.
+#
+# omarchy-nix's homeManagerModule has this code:
+#   config = lib.mkIf (osConfig ? omarchy) { omarchy = osConfig.omarchy; };
+# This causes evaluation errors if osConfig.omarchy doesn't exist.
+# We provide the option definitions here so osConfig.omarchy is available.
+{ lib, ... }:
+{
+  options.omarchy = {
+    full_name = lib.mkOption {
+      type = lib.types.str;
+      description = "Main user's full name";
+    };
+    email_address = lib.mkOption {
+      type = lib.types.str;
+      description = "Main user's email address";
+    };
+    theme = lib.mkOption {
+      type = lib.types.either (lib.types.enum [
+        "tokyo-night"
+        "kanagawa"
+        "everforest"
+        "catppuccin"
+        "nord"
+        "gruvbox"
+        "gruvbox-light"
+        "generated_light"
+        "generated_dark"
+      ]) lib.types.str;
+      default = "tokyo-night";
+      description = "Theme to use for Omarchy configuration";
+    };
+    theme_overrides = lib.mkOption {
+      type = lib.types.submodule {
+        options = {
+          wallpaper_path = lib.mkOption {
+            type = lib.types.nullOr lib.types.path;
+            default = null;
+            description = "Path to the wallpaper image to extract colors from";
+          };
+        };
+      };
+      default = { };
+      description = "Theme overrides including wallpaper path for generated themes";
+    };
+    primary_font = lib.mkOption {
+      type = lib.types.str;
+      default = "Liberation Sans 11";
+    };
+    vscode_settings = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+    };
+    monitors = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+    };
+    scale = lib.mkOption {
+      type = lib.types.int;
+      default = 2;
+      description = "Display scale factor (1 for 1x displays, 2 for 2x displays)";
+    };
+    quick_app_bindings = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      description = "A list of single keystroke key bindings to launch common apps.";
+      default = [ ];
+    };
+    exclude_packages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      description = "Packages to exclude from the default system packages";
+    };
+  };
+
+  # Provide default values for the options
+  # These will be overridden by the home-manager module's omarchy config
+  config.omarchy = {
+    full_name = lib.mkDefault "User";
+    email_address = lib.mkDefault "user@example.com";
+  };
+}

--- a/users/zanoni/home.nix
+++ b/users/zanoni/home.nix
@@ -20,7 +20,7 @@
     ../../home/modules/fonts.nix
     ../../home/modules/fuzzel.nix
     ../../home/modules/gnome
-    ../../home/modules/hyprland
+    ../../home/modules/omarchy
     ../../home/modules/ia-work.nix
     ../../home/modules/ksnip.nix
     ../../home/modules/install-nothing.nix

--- a/users/zanoni/home/git.nix
+++ b/users/zanoni/home/git.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 let
   gitconfig = builtins.readFile ../../../.gitconfig;
   userName = "Castrozan";
@@ -14,8 +14,8 @@ in
     enable = true;
     ignores = [ ".claude-context" ];
     settings = {
-      user.name = userName;
-      user.email = userEmail;
+      user.name = lib.mkForce userName;
+      user.email = lib.mkForce userEmail;
     };
   };
 

--- a/users/zanoni/nixos.nix
+++ b/users/zanoni/nixos.nix
@@ -3,10 +3,12 @@
   lib,
   pkgs,
   ...
-}: let
+}:
+let
   bashrc = builtins.readFile ../../.bashrc;
   sshKeys = import ./ssh-keys.nix;
-in {
+in
+{
   imports = [
     ./scripts
     ./pkgs.nix
@@ -23,6 +25,15 @@ in {
 
   # Disable lid switch suspend for laptop used as server/with external monitor
   custom.lidSwitch.disable = true;
+
+  # Omarchy configuration (required by omarchy-nix homeManagerModule)
+  omarchy = {
+    full_name = "Lucas Zanoni";
+    email_address = "lucas@zanoni.dev";
+    theme = "tokyo-night";
+    scale = 1;
+    monitors = [ "HDMI-A-1" ];
+  };
 
   users.users.zanoni = {
     isNormalUser = true;
@@ -78,7 +89,7 @@ in {
 
   networking.firewall = {
     enable = true;
-    allowedTCPPorts = [22];
+    allowedTCPPorts = [ 22 ];
   };
 
   users.users.zanoni.openssh.authorizedKeys.keys = sshKeys.authorizedKeys;


### PR DESCRIPTION
## Summary
- Integrates [omarchy-nix](https://github.com/henrysipp/omarchy-nix) for Hyprland window manager configuration
- Keeps existing app preferences: wezterm terminal, brave browser
- Adds waybar with tokyo-night theme
- Lowers mouse sensitivity to -0.3
- Fixes wezterm startup error (gui-attached handler)
- Adds blueberry for bluetooth management

## Changes
- **flake.nix**: Added omarchy-nix input
- **home/modules/omarchy/**: New omarchy integration module with overrides
- **nixos/modules/omarchy/**: NixOS-level omarchy options for osConfig compatibility
- **users/zanoni/nixos.nix**: Set omarchy options at NixOS level
- **wezterm.lua**: Fixed nil error in gui-attached handler
- **git.nix**: Use mkForce to prevent conflict with omarchy git settings
- **dconf.nix**: Use mkForce for gtk-theme to prevent conflict

## Test plan
- [ ] Run `sudo nixos-rebuild switch --flake ~/.dotfiles#zanoni`
- [ ] Verify Hyprland starts with waybar
- [ ] Test wezterm launches without errors
- [ ] Test waybar bluetooth click (blueberry)
- [ ] Verify mouse sensitivity is lower