### PR TITLE
fix(wezterm): send CSI-u sequence for Shift+Enter

### DIFF
--- a/.config/wezterm/wezterm.lua
+++ b/.config/wezterm/wezterm.lua
@@ -3,9 +3,6 @@
 
 local wezterm = require 'wezterm'
 
--- Detect Wayland vs X11 for different Shift+Enter handling
-local is_wayland = os.getenv('WAYLAND_DISPLAY') ~= nil
-
 -- Catppuccin Mocha color scheme
 local catppuccin_mocha = {
   -- Basic colors
@@ -150,8 +147,8 @@ return {
 
   -- Key bindings
   keys = {
-    -- Shift+Enter: CSI-u sequence on Wayland (Hyprland), raw newline on X11 (GNOME)
-    { key = 'Enter', mods = 'SHIFT', action = wezterm.action.SendString(is_wayland and '\x1b[13;2u' or '\n') },
+    -- Shift+Enter: send CSI-u sequence for multi-line input in apps like Claude Code
+    { key = 'Enter', mods = 'SHIFT', action = wezterm.action.SendString('\x1b[13;2u') },
     -- Ctrl+Enter: send \x1b[13;5u (5 = Ctrl modifier) for apps that need it
     { key = 'Enter', mods = 'CTRL', action = wezterm.action.SendString('\x1b[13;5u') },
     -- Alt+Enter: send \x1b[13;3u (3 = Alt modifier)

--- a/.config/wezterm/wezterm.lua
+++ b/.config/wezterm/wezterm.lua
@@ -147,8 +147,8 @@ return {
 
   -- Key bindings
   keys = {
-    -- Shift+Enter: send newline character for multi-line input
-    { key = 'Enter', mods = 'SHIFT', action = wezterm.action.SendString('\n') },
+    -- Shift+Enter: send CSI-u sequence \x1b[13;2u (2 = Shift modifier) for multi-line input
+    { key = 'Enter', mods = 'SHIFT', action = wezterm.action.SendString('\x1b[13;2u') },
     -- Ctrl+Enter: send \x1b[13;5u (5 = Ctrl modifier) for apps that need it
     { key = 'Enter', mods = 'CTRL', action = wezterm.action.SendString('\x1b[13;5u') },
     -- Alt+Enter: send \x1b[13;3u (3 = Alt modifier)

--- a/.config/wezterm/wezterm.lua
+++ b/.config/wezterm/wezterm.lua
@@ -3,6 +3,9 @@
 
 local wezterm = require 'wezterm'
 
+-- Detect Wayland vs X11 for different Shift+Enter handling
+local is_wayland = os.getenv('WAYLAND_DISPLAY') ~= nil
+
 -- Catppuccin Mocha color scheme
 local catppuccin_mocha = {
   -- Basic colors
@@ -147,8 +150,8 @@ return {
 
   -- Key bindings
   keys = {
-    -- Shift+Enter: send CSI-u sequence \x1b[13;2u (2 = Shift modifier) for multi-line input
-    { key = 'Enter', mods = 'SHIFT', action = wezterm.action.SendString('\x1b[13;2u') },
+    -- Shift+Enter: CSI-u sequence on Wayland (Hyprland), raw newline on X11 (GNOME)
+    { key = 'Enter', mods = 'SHIFT', action = wezterm.action.SendString(is_wayland and '\x1b[13;2u' or '\n') },
     -- Ctrl+Enter: send \x1b[13;5u (5 = Ctrl modifier) for apps that need it
     { key = 'Enter', mods = 'CTRL', action = wezterm.action.SendString('\x1b[13;5u') },
     -- Alt+Enter: send \x1b[13;3u (3 = Alt modifier)

--- a/.config/wezterm/wezterm.lua
+++ b/.config/wezterm/wezterm.lua
@@ -3,6 +3,9 @@
 
 local wezterm = require 'wezterm'
 
+-- Detect Hyprland for different Shift+Enter handling
+local is_hyprland = os.getenv('HYPRLAND_INSTANCE_SIGNATURE') ~= nil
+
 -- Catppuccin Mocha color scheme
 local catppuccin_mocha = {
   -- Basic colors
@@ -147,8 +150,8 @@ return {
 
   -- Key bindings
   keys = {
-    -- Shift+Enter: send CSI-u sequence for multi-line input in apps like Claude Code
-    { key = 'Enter', mods = 'SHIFT', action = wezterm.action.SendString('\x1b[13;2u') },
+    -- Shift+Enter: CSI-u sequence on Hyprland, raw newline on GNOME
+    { key = 'Enter', mods = 'SHIFT', action = wezterm.action.SendString(is_hyprland and '\x1b[13;2u' or '\n') },
     -- Ctrl+Enter: send \x1b[13;5u (5 = Ctrl modifier) for apps that need it
     { key = 'Enter', mods = 'CTRL', action = wezterm.action.SendString('\x1b[13;5u') },
     -- Alt+Enter: send \x1b[13;3u (3 = Alt modifier)


### PR DESCRIPTION
## Summary
- Changes Shift+Enter key binding from sending raw `\n` to proper CSI-u escape sequence `\x1b[13;2u`
- Aligns with Ctrl+Enter and Alt+Enter which already use CSI-u format
- Fixes Shift+Enter not working in Claude Code on Hyprland/Wayland

## Test plan
- [ ] Rebuild: `rebuild` or dry-run with `nix build`
- [ ] Open WezTerm on Hyprland
- [ ] Run Claude Code and test Shift+Enter for multi-line input