### PR TITLE
feat(hooks): add rebuild-notify hook

### DIFF
--- a/agents/hooks/rebuild-notify.py
+++ b/agents/hooks/rebuild-notify.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""rebuild-notify.py - Notify before rebuild commands that will affect the system."""
+
+import json
+import re
+import sys
+
+REBUILD_PATTERNS = [
+    (r"nixos-rebuild\s+switch", "NixOS system rebuild"),
+    (r"nixos-rebuild\s+test", "NixOS test rebuild (not permanent)"),
+    (r"nixos-rebuild\s+boot", "NixOS boot rebuild (activates on reboot)"),
+    (r"home-manager\s+switch", "home-manager profile switch"),
+    (r"nix\s+run\s+.*home-manager.*switch", "home-manager switch via nix run"),
+    (r"nix\s+build\s+.*homeConfigurations", "building home-manager configuration"),
+    (r"nix\s+build\s+.*nixosConfigurations", "building NixOS configuration"),
+    (r"\./bin/rebuild", "dotfiles rebuild script"),
+    (r"~/\.dotfiles/bin/rebuild", "dotfiles rebuild script"),
+    (r"\$HOME/\.dotfiles/bin/rebuild", "dotfiles rebuild script"),
+]
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        sys.exit(1)
+
+    command = data.get("tool_input", {}).get("command", "")
+
+    if not command:
+        sys.exit(0)
+
+    for pattern, description in REBUILD_PATTERNS:
+        if re.search(pattern, command, re.IGNORECASE):
+            output = {
+                "continue": True,
+                "systemMessage": (
+                    f"🔄 REBUILD: {description}\n"
+                    "This will apply Nix configuration changes to the system."
+                )
+            }
+            print(json.dumps(output))
+            sys.exit(0)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/home/modules/claude/hook-config.nix
+++ b/home/modules/claude/hook-config.nix
@@ -54,6 +54,11 @@ in
           command = "${runHook} ${hooksPath}/branch-protection.py";
           timeout = 5000;
         }
+        {
+          type = "command";
+          command = "${runHook} ${hooksPath}/rebuild-notify.py";
+          timeout = 3000;
+        }
       ];
     }
   ];


### PR DESCRIPTION
## Summary
- Adds `rebuild-notify.py` hook that triggers before rebuild commands
- Notifies when running: nixos-rebuild, home-manager switch, nix build with configurations, ./bin/rebuild
- Provides system message to confirm Nix configuration changes will be applied

## Test plan
- [x] Hook script tested directly with all patterns (home-manager, nixos-rebuild, nix build, ./bin/rebuild)
- [x] Hook installed via home-manager and visible in ~/.claude/hooks/
- [x] Hook configured in settings.json under PreToolUse.Bash
- [x] Rebuilt from main to stable state after testing