### PR TITLE
feat(hyprland): add GNOME-like super key launcher

### DIFF
--- a/.config/hypr/user/bindings.conf
+++ b/.config/hypr/user/bindings.conf
@@ -7,6 +7,9 @@ $editor = code
 $fileManager = nautilus
 $browser = brave
 
+# Super key alone (on release) opens fuzzel and unmaximizes active window (GNOME-like)
+bindrd = SUPER, Super_L, GNOME-like launcher, exec, omarchy-super-launcher
+
 # Additional user bindings can go here
 # Example: bind = $mainMod, Y, exec, your-custom-command
 

--- a/bin/omarchy/super-launcher
+++ b/bin/omarchy/super-launcher
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# GNOME-like super key behavior: unmaximize window if maximized, then launch fuzzel
+# If fuzzel is cancelled (Esc/Super), restore maximize state
+
+activewindow=$(hyprctl activewindow -j)
+fullscreen=$(echo "$activewindow" | jq -r '.fullscreen')
+address=$(echo "$activewindow" | jq -r '.address')
+
+was_maximized=false
+if [[ "$fullscreen" == "1" ]]; then
+    was_maximized=true
+    hyprctl dispatch fullscreen 1
+fi
+
+# Get window count before fuzzel
+windows_before=$(hyprctl clients -j | jq 'length')
+
+fuzzel
+
+# Small delay to let any launched app create its window
+sleep 0.15
+
+# Get window count after fuzzel
+windows_after=$(hyprctl clients -j | jq 'length')
+
+# If no new window was created and original was maximized, restore it
+if [[ "$was_maximized" == "true" && "$windows_after" -le "$windows_before" ]]; then
+    hyprctl dispatch focuswindow "address:$address"
+    hyprctl dispatch fullscreen 1
+fi

--- a/home/modules/hyprland/omarchy-scripts.nix
+++ b/home/modules/hyprland/omarchy-scripts.nix
@@ -15,5 +15,6 @@ in
     (mkScript "omarchy-restart-hyprctl" ../../../bin/omarchy/restart-hyprctl)
     (mkScript "omarchy-restart-mako" ../../../bin/omarchy/restart-mako)
     (mkScript "omarchy-menu" ../../../bin/omarchy/menu)
+    (mkScript "omarchy-super-launcher" ../../../bin/omarchy/super-launcher)
   ];
 }


### PR DESCRIPTION
## Summary
- Add Super key (press and release) binding to launch fuzzel launcher
- Automatically unmaximize maximized windows before opening launcher
- Mimics GNOME's Super key behavior for Activities overview

## Test plan
- [ ] Rebuild from worktree
- [ ] Press Super on a non-maximized window → fuzzel opens
- [ ] Press Super on a maximized window → window unmaximizes, then fuzzel opens
- [ ] Verify existing Super+key combos still work (Super+D, Super+Space, etc.)