### PR TITLE
feat(hyprland): add fuzzel-based window switcher

### DIFF
--- a/.config/hypr/user/bindings.conf
+++ b/.config/hypr/user/bindings.conf
@@ -13,21 +13,12 @@ bindrd = SUPER, Super_L, GNOME-like launcher, exec, omarchy-super-launcher
 # Additional user bindings can go here
 # Example: bind = $mainMod, Y, exec, your-custom-command
 
-# Unbind omarchy tab defaults to override them
+# Window switcher: hyprshell handles Alt+Tab and Super+Tab
+# Unbind omarchy defaults so hyprshell plugin can take over
 unbind = ALT, TAB
 unbind = ALT SHIFT, TAB
 unbind = SUPER, TAB
 unbind = SUPER SHIFT, TAB
-
-# Override tab cycling to be workspace-only with history-based ordering
-bindd = ALT, TAB, Cycle next (ws), cyclenext, hist
-bindd = ALT, TAB, Bring to top, bringactivetotop
-bindd = ALT SHIFT, TAB, Cycle next (ws), cyclenext
-bindd = ALT SHIFT, TAB, Bring to top, bringactivetotop
-bindd = SUPER, TAB, Cycle last (ws), cyclenext, hist
-bindd = SUPER, TAB, Bring to top, bringactivetotop
-bindd = SUPER SHIFT, TAB, Cycle next (ws), cyclenext
-bindd = SUPER SHIFT, TAB, Bring to top, bringactivetotop
 
 # Unbind omarchy workspace defaults to override them
 unbind = SUPER CTRL, UP

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,10 @@
       url = "github:hyprwm/hyprland-plugins/v0.53.0";
       inputs.hyprland.follows = "hyprland";
     };
+    hyprshell = {
+      url = "github:H3rmt/hyprshell/hyprshell-release";
+      inputs.hyprland.follows = "hyprland";
+    };
   };
 
   # Outputs are what this flake provides, such as pkgs and system configurations

--- a/home/modules/hyprland/default.nix
+++ b/home/modules/hyprland/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ./hyprland.nix
     ./hyprexpo.nix
+    ./hyprshell.nix
     ./wlogout.nix
   ];
 }

--- a/home/modules/hyprland/hyprshell.nix
+++ b/home/modules/hyprland/hyprshell.nix
@@ -1,0 +1,41 @@
+{ pkgs, inputs, ... }:
+{
+  imports = [ inputs.hyprshell.homeModules.hyprshell ];
+
+  programs.hyprshell = {
+    enable = true;
+    # Use flake package to match Hyprland 0.53.0
+    package = inputs.hyprshell.packages.${pkgs.stdenv.hostPlatform.system}.hyprshell;
+
+    systemd = {
+      enable = true;
+      target = "hyprland-session.target";
+    };
+
+    settings = {
+      windows = {
+        enable = true;
+        scale = 8.5;
+        items_per_row = 5;
+
+        # Alt+Tab window switcher
+        switch = {
+          enable = true;
+          key = "Tab";
+          modifier = "alt";
+          filter_by = [ ];
+          switch_workspaces = false;
+        };
+
+        # Super+Tab window switcher
+        switch_2 = {
+          enable = true;
+          key = "Tab";
+          modifier = "super";
+          filter_by = [ ];
+          switch_workspaces = false;
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `omarchy-window-switcher` script using fuzzel for window selection
- Super+Tab and Alt+Tab open the window picker
- Tab cycles through options in fuzzel, Enter selects

## Current Status: Research Phase

The simple fuzzel-based implementation works but doesn't provide the classic "hold modifier, tap to cycle, release to select" behavior with window previews. Research below documents better solutions.

---

## 🔬 Research: Window Switcher Options for Hyprland

### Requirements
1. **Classic Alt+Tab behavior**: Hold Super/Alt, tap Tab to cycle, release to select
2. **Window previews/thumbnails**: Visual preview of windows while cycling
3. **Pretty/aesthetic**: Fits with rice aesthetic
4. **NixOS compatible**: Can be packaged/configured via flake

---

### Option 1: Hyprshell (formerly Hyprswitch) ⭐ RECOMMENDED
**GitHub**: https://github.com/H3rmt/hyprshell

**Features**:
- GTK4-based modern UI with window switching GUI
- Customizable keybindings for window switching
- Application launcher with frecency sorting
- CSS theming support (full customization)
- Dynamic config reload without restart
- **NixOS**: Has flake + home-manager module

**Requirements**: gtk4 v4.18+, libadwaita v1.8+, gtk4-layer-shell 1.1.1+

**Installation (NixOS)**:
```nix
inputs.hyprshell.url = "github:H3rmt/hyprshell";
# Use home-manager module for config
```

**Pros**: Active development, NixOS support, full theming, modern GTK4 UI
**Cons**: Heavy dependencies (GTK4 stack), no built-in window previews (just icons/titles)

---

### Option 2: Hycov Plugin ⭐ BEST FOR PREVIEWS
**GitHub**: https://github.com/DreamMaoMao/hycov

**Features**:
- **Grid overview mode** - tiles ALL windows in a grid for visual selection
- Perfect state recovery (fullscreen, floating, size, position)
- Multiple triggers: keyboard, touchpad gestures, hot corners
- Alt switch mode: hold Alt+Tab to enter overview, cycle while held, release to select
- Multi-monitor support

**Installation**:
```bash
hyprpm add https://github.com/DreamMaoMao/hycov
hyprpm enable hycov
```

**Config**:
```conf
bind = ALT,tab,hycov:toggleoverview
bind = ALT,left,hycov:movefocus,l
```

**Pros**: Actual window previews in grid, macOS Exposé-like, native Hyprland plugin
**Cons**: ⚠️ ARCHIVED (July 2024), may break with Hyprland updates, hyprpm not supported on NixOS

---

### Option 3: Hyprtabs
**GitHub**: https://github.com/ilovecrayons/hyprtabs

**Features**:
- True Alt-Tab cycling: hold Alt, tap Tab to cycle, release to select
- Shows both active and minimized/hidden windows
- Minimal dependencies (no eww)

**Pros**: Lightweight, proper hold-to-cycle behavior
**Cons**: No window previews, basic text-based UI

---

### Option 4: hyprland-alt-tab Script
**GitHub**: https://github.com/offGustavo/hyprland-alt-tab

**Features**:
- Focus history-based switching (like Windows/KDE)
- `--visible` flag for multi-monitor filtering
- `--same` flag for same-app cycling
- Session state persistence for rapid cycling
- Visual feedback via `dim_inactive`

**Pros**: Pure shell script, lightweight, smart filtering
**Cons**: No GUI, no previews

---

### Option 5: AGS/Astal Custom Widget
**GitHub**: https://github.com/Aylur/ags

**Features**:
- Build custom GTK4 widgets with JavaScript/TypeScript
- Full control over appearance and behavior
- Can integrate with Hyprland IPC for window data
- Screenshot windows using grim for previews

**Examples**:
- [end-4/dots-hyprland](https://github.com/end-4/dots-hyprland) - Popular rice with custom AGS widgets
- [Matshell](https://github.com/Neurarian/matshell) - Material Design shell with AGS

**Pros**: Unlimited customization, can implement any UI
**Cons**: Significant development effort, need to build from scratch

---

### Option 6: Hyprexpo (Built-in Plugin)
**Already in dotfiles**: `home/modules/hyprland/hyprexpo.nix`

**Features**:
- Workspace overview with live previews
- Grid layout of all workspaces
- Mouse/keyboard/gesture navigation

**Limitation**: Shows workspaces, not individual windows

---

## 📋 Recommendation

### For Quick Implementation: **Hyprshell**
- Best NixOS support
- Active development
- Good enough for basic switching
- Add to flake inputs, configure via home-manager

### For Best Visual Experience: **Hycov** (if still compatible)
- Actual window grid with previews
- macOS Exposé-like experience
- Risk: archived project, may break

### For Full Control: **Custom AGS Widget**
- Build exactly what you want
- Use grim to capture window thumbnails
- Most effort but best result

---

## 🔧 Implementation Plan

1. **Phase 1**: Try Hyprshell
   - Add flake input
   - Configure home-manager module
   - Test Alt+Tab behavior

2. **Phase 2**: Evaluate Hycov compatibility
   - Check if works with current Hyprland version
   - Build via overlay if needed

3. **Phase 3** (if needed): Custom AGS widget
   - Use Hyprland IPC for window list
   - Use grim + slurp for window thumbnails
   - Build custom overlay UI

---

## Test plan
- [ ] Research complete
- [ ] Select implementation approach
- [ ] Implement chosen solution
- [ ] Test hold-to-cycle behavior
- [ ] Test window previews
- [ ] Verify NixOS rebuild works