### PR TITLE
feat(waybar): add calendar popup to clock module

### DIFF
--- a/.config/hypr/user/bindings.conf
+++ b/.config/hypr/user/bindings.conf
@@ -53,7 +53,7 @@ bindd = CTRL ALT SHIFT, LEFT, Move win left, exec, hyprctl dispatch movetoworksp
 bindd = CTRL ALT SHIFT, RIGHT, Move win right, exec, hyprctl dispatch movetoworkspace $(( $(hyprctl activeworkspace -j | jq '.id') + 1 ))
 
 # Calendar popup
-bindd = SUPER, K, Toggle calendar, exec, ~/.config/waybar/calendar-toggle.sh
+bindd = SUPER, Y, Toggle calendar, exec, ~/.config/waybar/calendar-toggle.sh
 
 # Hyprland plugins
 source = ~/.config/hyprexpo.conf

--- a/.config/hypr/user/bindings.conf
+++ b/.config/hypr/user/bindings.conf
@@ -52,5 +52,8 @@ bindd = CTRL ALT SHIFT, DOWN, Move win down, exec, hyprctl dispatch movetoworksp
 bindd = CTRL ALT SHIFT, LEFT, Move win left, exec, hyprctl dispatch movetoworkspace $(( $(hyprctl activeworkspace -j | jq '.id') - 1 ))
 bindd = CTRL ALT SHIFT, RIGHT, Move win right, exec, hyprctl dispatch movetoworkspace $(( $(hyprctl activeworkspace -j | jq '.id') + 1 ))
 
+# Calendar popup
+bindd = SUPER, K, Toggle calendar, exec, ~/.config/waybar/calendar-toggle.sh
+
 # Hyprland plugins
 source = ~/.config/hyprexpo.conf

--- a/.config/waybar/calendar-popup.py
+++ b/.config/waybar/calendar-popup.py
@@ -63,6 +63,17 @@ class CalendarWindow(Gtk.Window):
         calendar:indeterminate {
             color: #6c7086;
         }
+        button.close {
+            background-color: transparent;
+            border: none;
+            color: #6c7086;
+            padding: 4px 8px;
+            min-width: 0;
+            min-height: 0;
+        }
+        button.close:hover {
+            color: #f38ba8;
+        }
         """
         style_provider = Gtk.CssProvider()
         style_provider.load_from_data(css)
@@ -72,12 +83,26 @@ class CalendarWindow(Gtk.Window):
             Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
         )
 
+        # Main container
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+
+        # Header with close button
+        header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+        header.set_halign(Gtk.Align.END)
+        close_btn = Gtk.Button(label="✕")
+        close_btn.get_style_context().add_class("close")
+        close_btn.connect("clicked", lambda x: Gtk.main_quit())
+        header.pack_end(close_btn, False, False, 8)
+        vbox.pack_start(header, False, False, 4)
+
+        # Calendar
         calendar = Gtk.Calendar()
         calendar.set_property("show-heading", True)
         calendar.set_property("show-day-names", True)
         calendar.set_property("show-week-numbers", False)
+        vbox.pack_start(calendar, True, True, 0)
 
-        self.add(calendar)
+        self.add(vbox)
 
     def on_key_press(self, widget, event):
         if event.keyval == Gdk.KEY_Escape:

--- a/.config/waybar/calendar-popup.py
+++ b/.config/waybar/calendar-popup.py
@@ -17,7 +17,7 @@ class CalendarWindow(Gtk.Window):
         except:
             screen_width = 1920
 
-        width, height = 500, 350
+        width, height = 540, 350
 
         self.set_default_size(width, height)
         self.set_decorated(False)
@@ -64,15 +64,17 @@ class CalendarWindow(Gtk.Window):
             color: #6c7086;
         }
         button.close {
-            background-color: transparent;
+            background-color: #94e2d5;
             border: none;
-            color: #6c7086;
-            padding: 4px 8px;
+            border-radius: 6px;
+            color: #1e1e2e;
+            padding: 2px 8px;
             min-width: 0;
             min-height: 0;
+            font-weight: bold;
         }
         button.close:hover {
-            color: #f38ba8;
+            background-color: #89b4fa;
         }
         """
         style_provider = Gtk.CssProvider()
@@ -86,14 +88,23 @@ class CalendarWindow(Gtk.Window):
         # Main container
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
 
-        # Header with close button
+        # Header row with close button at far right
         header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
-        header.set_halign(Gtk.Align.END)
+        header.set_margin_top(8)
+        header.set_margin_end(10)
+
+        # Spacer to push close button to the right
+        spacer = Gtk.Box()
+        spacer.set_hexpand(True)
+        header.pack_start(spacer, True, True, 0)
+
+        # Close button
         close_btn = Gtk.Button(label="✕")
         close_btn.get_style_context().add_class("close")
         close_btn.connect("clicked", lambda x: Gtk.main_quit())
-        header.pack_end(close_btn, False, False, 8)
-        vbox.pack_start(header, False, False, 4)
+        header.pack_end(close_btn, False, False, 0)
+
+        vbox.pack_start(header, False, False, 0)
 
         # Calendar
         calendar = Gtk.Calendar()

--- a/.config/waybar/calendar-popup.py
+++ b/.config/waybar/calendar-popup.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk, Gdk
+import subprocess
+import json
+
+class CalendarWindow(Gtk.Window):
+    def __init__(self):
+        super().__init__(title="Calendar")
+
+        # Get monitor width for centering
+        try:
+            result = subprocess.run(['hyprctl', 'monitors', '-j'], capture_output=True, text=True)
+            monitors = json.loads(result.stdout)
+            screen_width = monitors[0]['width']
+        except:
+            screen_width = 1920
+
+        width, height = 500, 350
+
+        self.set_default_size(width, height)
+        self.set_decorated(False)
+        self.set_resizable(False)
+        self.set_keep_above(True)
+        self.set_skip_taskbar_hint(True)
+        self.set_position(Gtk.WindowPosition.NONE)
+        self.move((screen_width - width) // 2, 40)
+
+        # Close on escape
+        self.connect("key-press-event", self.on_key_press)
+
+        # Style
+        css = b"""
+        window {
+            background-color: #1e1e2e;
+            border-radius: 12px;
+            border: none;
+        }
+        calendar {
+            background-color: #1e1e2e;
+            color: #cdd6f4;
+            font-size: 18px;
+            padding: 12px;
+            border: none;
+        }
+        calendar.header {
+            border: none;
+            background-color: #1e1e2e;
+        }
+        calendar:selected {
+            background-color: #94e2d5;
+            color: #1e1e2e;
+        }
+        calendar.header {
+            color: #cdd6f4;
+            font-weight: bold;
+            font-size: 20px;
+        }
+        calendar.button {
+            color: #89b4fa;
+        }
+        calendar:indeterminate {
+            color: #6c7086;
+        }
+        """
+        style_provider = Gtk.CssProvider()
+        style_provider.load_from_data(css)
+        Gtk.StyleContext.add_provider_for_screen(
+            Gdk.Screen.get_default(),
+            style_provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        )
+
+        calendar = Gtk.Calendar()
+        calendar.set_property("show-heading", True)
+        calendar.set_property("show-day-names", True)
+        calendar.set_property("show-week-numbers", False)
+
+        self.add(calendar)
+
+    def on_key_press(self, widget, event):
+        if event.keyval == Gdk.KEY_Escape:
+            Gtk.main_quit()
+
+win = CalendarWindow()
+win.connect("destroy", Gtk.main_quit)
+win.show_all()
+Gtk.main()

--- a/.config/waybar/calendar-toggle.sh
+++ b/.config/waybar/calendar-toggle.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Toggle calendar popup - close if open, open if closed
+if pkill -f "calendar-popup.py"; then
+    exit 0
+else
+    python3 ~/.config/waybar/calendar-popup.py &
+fi

--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -39,9 +39,27 @@
     "tooltip-format": "CPU: {usage}%"
   },
   "clock": {
-    "format": "{:L%A %H:%M}",
-    "format-alt": "{:L%d %B W%V %Y}",
-    "tooltip": false
+    "format": "{:%d %b %a  %H:%M}",
+    "tooltip": true,
+    "tooltip-format": "<tt><small>{calendar}</small></tt>",
+    "calendar": {
+      "mode": "month",
+      "mode-mon-col": 3,
+      "weeks-pos": "left",
+      "on-scroll": 1,
+      "format": {
+        "months": "<span color='#cdd6f4'><b>{}</b></span>",
+        "days": "<span color='#6c7086'>{}</span>",
+        "weeks": "<span color='#94e2d5'>W{}</span>",
+        "weekdays": "<span color='#89b4fa'><b>{}</b></span>",
+        "today": "<span color='#1e1e2e' bgcolor='#94e2d5'><b>{}</b></span>"
+      }
+    },
+    "actions": {
+      "on-click-right": "mode",
+      "on-scroll-up": "shift_up",
+      "on-scroll-down": "shift_down"
+    }
   },
   "network": {
     "format-icons": ["󰤯", "󰤟", "󰤢", "󰤥", "󰤨"],

--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -41,7 +41,8 @@
   "clock": {
     "format": "{:%d %b %a  %H:%M}",
     "tooltip": true,
-    "tooltip-format": "<tt><small>{calendar}</small></tt>",
+    "tooltip-format": "<tt><big>{calendar}</big></tt>",
+    "on-click": "yad --calendar --undecorated --fixed --close-on-unfocus --no-buttons --posx=860 --posy=40",
     "calendar": {
       "mode": "month",
       "mode-mon-col": 3,

--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -42,7 +42,7 @@
     "format": "{:%d %b %a  %H:%M}",
     "tooltip": true,
     "tooltip-format": "<tt><big>{calendar}</big></tt>",
-    "on-click": "bash -c 'w=$(hyprctl monitors -j | jq \".[0].width\"); yad --calendar --undecorated --fixed --no-buttons --skip-taskbar --on-top --width=400 --height=300 --fontname=\"JetBrainsMono Nerd Font 14\" --posx=$((($w - 400) / 2)) --posy=40'",
+    "on-click": "python3 ~/.config/waybar/calendar-popup.py",
     "calendar": {
       "mode": "month",
       "mode-mon-col": 3,

--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -42,7 +42,7 @@
     "format": "{:%d %b %a  %H:%M}",
     "tooltip": true,
     "tooltip-format": "<tt><big>{calendar}</big></tt>",
-    "on-click": "yad --calendar --undecorated --fixed --close-on-unfocus --no-buttons --posx=860 --posy=40",
+    "on-click": "bash -c 'w=$(hyprctl monitors -j | jq \".[0].width\"); yad --calendar --undecorated --fixed --no-buttons --skip-taskbar --on-top --width=400 --height=300 --fontname=\"JetBrainsMono Nerd Font 14\" --posx=$((($w - 400) / 2)) --posy=40'",
     "calendar": {
       "mode": "month",
       "mode-mon-col": 3,

--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -42,7 +42,7 @@
     "format": "{:%d %b %a  %H:%M}",
     "tooltip": true,
     "tooltip-format": "<tt><big>{calendar}</big></tt>",
-    "on-click": "python3 ~/.config/waybar/calendar-popup.py",
+    "on-click": "~/.config/waybar/calendar-toggle.sh",
     "calendar": {
       "mode": "month",
       "mode-mon-col": 3,

--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -87,3 +87,26 @@ tooltip {
 #clock {
   margin-left: 8.75px;
 }
+
+#calendar {
+  background-color: @background;
+  color: @foreground;
+  border-radius: 8px;
+  padding: 6px;
+}
+
+#calendar.header {
+  color: @accent;
+  font-weight: bold;
+}
+
+#calendar.weekday {
+  color: @primary;
+}
+
+#calendar.today {
+  color: @background;
+  background-color: @accent;
+  font-weight: bold;
+  border-radius: 4px;
+}

--- a/.config/waybar/style.css
+++ b/.config/waybar/style.css
@@ -81,7 +81,9 @@ window#waybar {
 tooltip {
   background-color: @background;
   border: 1px solid @surface;
-  padding: 2px;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 14px;
 }
 
 #clock {

--- a/home/modules/hyprland/hyprland.nix
+++ b/home/modules/hyprland/hyprland.nix
@@ -126,6 +126,9 @@ in
       # Calculator
       gnome-calculator
 
+      # Calendar popup for waybar
+      yad
+
       # Bluetooth manager
       blueman
 


### PR DESCRIPTION
## Summary
- Updated waybar clock format to show "24 Jan Fri  14:30" (day month weekday time)
- Added calendar popup tooltip on hover with week numbers
- Styled calendar to match theme colors (teal accent for today, blue for weekdays)
- Added interactions: right-click toggles year view, scroll navigates months

## Test plan
- [ ] Start Hyprland session
- [ ] Verify clock shows in new format: day month weekday time
- [ ] Hover over clock to see calendar popup
- [ ] Verify today is highlighted with teal background
- [ ] Verify week numbers appear on left side
- [ ] Right-click on clock to toggle year view
- [ ] Scroll on clock to navigate between months