### PR TITLE
feat(waybar): add fuzzel-based bluetooth menu

### DIFF
--- a/.config/waybar/config
+++ b/.config/waybar/config
@@ -81,7 +81,8 @@
     "format-connected": "󰂱",
     "format-no-controller": "",
     "tooltip-format": "Devices connected: {num_connections}",
-    "on-click": "blueman-manager"
+    "on-click": "omarchy-bluetooth",
+    "on-click-right": "omarchy-bluetooth --full"
   },
   "pulseaudio": {
     "format": "{icon}",

--- a/bin/omarchy/bluetooth
+++ b/bin/omarchy/bluetooth
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+
+menu() {
+  local prompt="$1"
+  local options="$2"
+  local extra_args="$3"
+
+  read -r -a args <<<"$extra_args"
+  echo -e "$options" | fuzzel --dmenu --width 40 --lines 12 --prompt "$prompt> " "${args[@]}" 2>/dev/null
+}
+
+get_power_status() {
+  bluetoothctl show 2>/dev/null | grep -q "Powered: yes" && echo "on" || echo "off"
+}
+
+get_paired_devices() {
+  bluetoothctl devices Paired 2>/dev/null | sed 's/Device //'
+}
+
+get_connected_devices() {
+  bluetoothctl devices Connected 2>/dev/null | sed 's/Device //'
+}
+
+is_device_connected() {
+  local mac="$1"
+  bluetoothctl info "$mac" 2>/dev/null | grep -q "Connected: yes"
+}
+
+toggle_power() {
+  if [[ "$(get_power_status)" == "on" ]]; then
+    bluetoothctl power off
+    notify-send -t 2000 "Bluetooth" "Powered off"
+  else
+    bluetoothctl power on
+    notify-send -t 2000 "Bluetooth" "Powered on"
+  fi
+}
+
+scan_devices() {
+  notify-send -t 3000 "Bluetooth" "Scanning for devices..."
+  bluetoothctl --timeout 5 scan on &>/dev/null &
+
+  sleep 5
+
+  local devices
+  devices=$(bluetoothctl devices 2>/dev/null | sed 's/Device //')
+
+  if [[ -z "$devices" ]]; then
+    notify-send -t 2000 "Bluetooth" "No devices found"
+    show_main_menu
+    return
+  fi
+
+  local selection
+  selection=$(menu "Found Devices" "$devices" "--width 350")
+
+  if [[ -n "$selection" ]]; then
+    local mac name
+    mac=$(echo "$selection" | awk '{print $1}')
+    name=$(echo "$selection" | cut -d' ' -f2-)
+
+    case $(menu "Pair $name" "󰂱  Pair & Connect\n  Cancel") in
+      *Pair*)
+        notify-send -t 2000 "Bluetooth" "Pairing with $name..."
+        bluetoothctl pair "$mac" && bluetoothctl connect "$mac"
+        if [[ $? -eq 0 ]]; then
+          notify-send -t 2000 "Bluetooth" "Connected to $name"
+        else
+          notify-send -t 2000 "Bluetooth" "Failed to connect to $name"
+        fi
+        ;;
+    esac
+  fi
+
+  show_main_menu
+}
+
+show_paired_devices() {
+  local devices
+  devices=$(get_paired_devices)
+
+  if [[ -z "$devices" ]]; then
+    notify-send -t 2000 "Bluetooth" "No paired devices"
+    show_main_menu
+    return
+  fi
+
+  local formatted=""
+  while IFS= read -r line; do
+    local mac name
+    mac=$(echo "$line" | awk '{print $1}')
+    name=$(echo "$line" | cut -d' ' -f2-)
+    if is_device_connected "$mac"; then
+      formatted+="󰂱  $name ($mac)\n"
+    else
+      formatted+="󰂲  $name ($mac)\n"
+    fi
+  done <<<"$devices"
+  formatted="${formatted%\\n}"
+
+  local selection
+  selection=$(menu "Paired Devices" "$formatted" "--width 400")
+
+  if [[ -n "$selection" ]]; then
+    local mac
+    mac=$(echo "$selection" | grep -oE '([0-9A-F]{2}:){5}[0-9A-F]{2}')
+    local name
+    name=$(echo "$selection" | sed 's/^[^ ]* *//' | sed "s/ ($mac)//")
+
+    if is_device_connected "$mac"; then
+      case $(menu "$name" "󰂲  Disconnect\n  Remove\n  Cancel") in
+        *Disconnect*)
+          bluetoothctl disconnect "$mac"
+          notify-send -t 2000 "Bluetooth" "Disconnected from $name"
+          ;;
+        *Remove*)
+          bluetoothctl remove "$mac"
+          notify-send -t 2000 "Bluetooth" "Removed $name"
+          ;;
+      esac
+    else
+      case $(menu "$name" "󰂱  Connect\n  Remove\n  Cancel") in
+        *Connect*)
+          notify-send -t 2000 "Bluetooth" "Connecting to $name..."
+          if bluetoothctl connect "$mac"; then
+            notify-send -t 2000 "Bluetooth" "Connected to $name"
+          else
+            notify-send -t 2000 "Bluetooth" "Failed to connect"
+          fi
+          ;;
+        *Remove*)
+          bluetoothctl remove "$mac"
+          notify-send -t 2000 "Bluetooth" "Removed $name"
+          ;;
+      esac
+    fi
+  fi
+
+  show_main_menu
+}
+
+show_main_menu() {
+  local power_status power_icon power_text
+  power_status=$(get_power_status)
+
+  if [[ "$power_status" == "on" ]]; then
+    power_icon="󰂯"
+    power_text="Power Off"
+  else
+    power_icon="󰂲"
+    power_text="Power On"
+  fi
+
+  local connected
+  connected=$(get_connected_devices | wc -l)
+  local connected_text=""
+  if [[ "$connected" -gt 0 ]]; then
+    connected_text=" ($connected connected)"
+  fi
+
+  local options="󰂱  Paired Devices$connected_text\n󰂰  Scan for Devices\n$power_icon  $power_text\n󰒓  Open Settings"
+
+  case $(menu "Bluetooth" "$options") in
+    *Paired*) show_paired_devices ;;
+    *Scan*) scan_devices ;;
+    *Power*) toggle_power; show_main_menu ;;
+    *Settings*) blueman-manager & ;;
+  esac
+}
+
+if [[ "$1" == "--full" ]]; then
+  blueman-manager &
+else
+  show_main_menu
+fi

--- a/bin/omarchy/bluetooth
+++ b/bin/omarchy/bluetooth
@@ -14,16 +14,26 @@ get_power_status() {
 }
 
 get_paired_devices() {
-  bluetoothctl devices Paired 2>/dev/null | sed 's/Device //'
-}
-
-get_connected_devices() {
-  bluetoothctl devices Connected 2>/dev/null | sed 's/Device //'
+  bluetoothctl paired-devices 2>/dev/null | sed 's/Device //'
 }
 
 is_device_connected() {
   local mac="$1"
   bluetoothctl info "$mac" 2>/dev/null | grep -q "Connected: yes"
+}
+
+get_connected_devices() {
+  local devices connected=""
+  devices=$(bluetoothctl paired-devices 2>/dev/null | sed 's/Device //')
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    local mac
+    mac=$(echo "$line" | awk '{print $1}')
+    if is_device_connected "$mac"; then
+      connected+="$line\n"
+    fi
+  done <<<"$devices"
+  echo -e "${connected%\\n}"
 }
 
 toggle_power() {

--- a/bin/omarchy/bluetooth
+++ b/bin/omarchy/bluetooth
@@ -3,10 +3,9 @@
 menu() {
   local prompt="$1"
   local options="$2"
-  local extra_args="$3"
+  local lines="${3:-5}"
 
-  read -r -a args <<<"$extra_args"
-  echo -e "$options" | fuzzel --dmenu --width 40 --lines 12 --prompt "$prompt> " "${args[@]}" 2>/dev/null
+  echo -e "$options" | fuzzel --dmenu --width 30 --lines "$lines" --prompt "$prompt> " 2>/dev/null
 }
 
 get_power_status() {
@@ -62,14 +61,14 @@ scan_devices() {
   fi
 
   local selection
-  selection=$(menu "Found Devices" "$devices" "--width 350")
+  selection=$(menu "Found Devices" "$devices" 8)
 
   if [[ -n "$selection" ]]; then
     local mac name
     mac=$(echo "$selection" | awk '{print $1}')
     name=$(echo "$selection" | cut -d' ' -f2-)
 
-    case $(menu "Pair $name" "󰂱  Pair & Connect\n  Cancel") in
+    case $(menu "Pair $name" "󰂱  Pair & Connect\n  Cancel" 2) in
       *Pair*)
         notify-send -t 2000 "Bluetooth" "Pairing with $name..."
         bluetoothctl pair "$mac" && bluetoothctl connect "$mac"
@@ -109,7 +108,7 @@ show_paired_devices() {
   formatted="${formatted%\\n}"
 
   local selection
-  selection=$(menu "Paired Devices" "$formatted" "--width 400")
+  selection=$(menu "Paired Devices" "$formatted" 6)
 
   if [[ -n "$selection" ]]; then
     local mac
@@ -118,7 +117,7 @@ show_paired_devices() {
     name=$(echo "$selection" | sed 's/^[^ ]* *//' | sed "s/ ($mac)//")
 
     if is_device_connected "$mac"; then
-      case $(menu "$name" "󰂲  Disconnect\n  Remove\n  Cancel") in
+      case $(menu "$name" "󰂲  Disconnect\n  Remove\n  Cancel" 3) in
         *Disconnect*)
           bluetoothctl disconnect "$mac"
           notify-send -t 2000 "Bluetooth" "Disconnected from $name"
@@ -129,7 +128,7 @@ show_paired_devices() {
           ;;
       esac
     else
-      case $(menu "$name" "󰂱  Connect\n  Remove\n  Cancel") in
+      case $(menu "$name" "󰂱  Connect\n  Remove\n  Cancel" 3) in
         *Connect*)
           notify-send -t 2000 "Bluetooth" "Connecting to $name..."
           if bluetoothctl connect "$mac"; then
@@ -170,7 +169,7 @@ show_main_menu() {
 
   local options="󰂱  Paired Devices$connected_text\n󰂰  Scan for Devices\n$power_icon  $power_text\n󰒓  Open Settings"
 
-  case $(menu "Bluetooth" "$options") in
+  case $(menu "Bluetooth" "$options" 4) in
     *Paired*) show_paired_devices ;;
     *Scan*) scan_devices ;;
     *Power*) toggle_power; show_main_menu ;;

--- a/home/modules/hyprland/omarchy-scripts.nix
+++ b/home/modules/hyprland/omarchy-scripts.nix
@@ -16,5 +16,6 @@ in
     (mkScript "omarchy-restart-mako" ../../../bin/omarchy/restart-mako)
     (mkScript "omarchy-menu" ../../../bin/omarchy/menu)
     (mkScript "omarchy-super-launcher" ../../../bin/omarchy/super-launcher)
+    (mkScript "omarchy-bluetooth" ../../../bin/omarchy/bluetooth)
   ];
 }


### PR DESCRIPTION
## Summary
- Replace blueman-manager with lightweight fuzzel-based bluetooth menu
- Left-click opens quick menu with: paired devices, scan, power toggle
- Right-click opens full blueman-manager for advanced settings
- Consistent with existing omarchy menu patterns

## Features
- **Paired Devices**: Quick connect/disconnect with device status icons
- **Scan**: Discover and pair new devices
- **Power Toggle**: Quick on/off control
- **Settings**: Opens blueman-manager for advanced configuration

## Test plan
- [ ] Rebuild and switch to new configuration
- [ ] Click bluetooth icon in waybar - fuzzel menu should appear
- [ ] Test power toggle (on/off)
- [ ] Test connecting to a paired device
- [ ] Right-click should open blueman-manager