### PR TITLE
feat(hyprland): add Super+D show desktop keybind

### DIFF
--- a/.config/hypr/omarchy/bindings/utilities.conf
+++ b/.config/hypr/omarchy/bindings/utilities.conf
@@ -9,7 +9,7 @@ bindd = SUPER, B, Browser, exec, $browser
 bindd = SUPER, N, Neovim, exec, $terminal -e nvim
 
 bindd = SUPER, SPACE, Launcher, exec, fuzzel
-bindd = SUPER, D, Launcher, exec, fuzzel
+bindd = SUPER, D, Show desktop, exec, omarchy-show-desktop
 bindd = SUPER CTRL, E, Emoji, exec, BEMOJI_PICKER_CMD="fuzzel --dmenu" bemoji -t
 bindd = , XF86Calculator, Calculator, exec, gnome-calculator
 

--- a/bin/omarchy/show-desktop
+++ b/bin/omarchy/show-desktop
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Toggle show desktop: moves all windows to/from a special workspace
+# Tracks state per workspace to support multi-monitor setups
+
+STATE_DIR="${XDG_RUNTIME_DIR:-/tmp}/hyprland-show-desktop"
+mkdir -p "$STATE_DIR"
+
+current_workspace=$(hyprctl monitors -j | jq -r '.[] | select(.focused) | .activeWorkspace.id')
+state_file="$STATE_DIR/ws-$current_workspace"
+
+if [[ -f "$state_file" ]]; then
+    # Desktop is showing, restore windows
+    while IFS= read -r addr; do
+        hyprctl dispatch movetoworkspacesilent "$current_workspace,address:$addr"
+    done < "$state_file"
+    rm -f "$state_file"
+else
+    # Hide all windows to special workspace
+    windows=$(hyprctl clients -j | jq -r --argjson ws "$current_workspace" '.[] | select(.workspace.id == $ws) | .address')
+    if [[ -n "$windows" ]]; then
+        echo "$windows" > "$state_file"
+        echo "$windows" | while IFS= read -r addr; do
+            hyprctl dispatch movetoworkspacesilent "special:desktop,address:$addr"
+        done
+    fi
+fi

--- a/bin/omarchy/show-desktop
+++ b/bin/omarchy/show-desktop
@@ -7,17 +7,28 @@ mkdir -p "$STATE_DIR"
 
 current_workspace=$(hyprctl monitors -j | jq -r '.[] | select(.focused) | .activeWorkspace.id')
 state_file="$STATE_DIR/ws-$current_workspace"
+focus_file="$STATE_DIR/focus-$current_workspace"
 
 if [[ -f "$state_file" ]]; then
     # Desktop is showing, restore windows
     while IFS= read -r addr; do
         hyprctl dispatch movetoworkspacesilent "$current_workspace,address:$addr"
     done < "$state_file"
+
+    # Restore focus to previously active window
+    if [[ -f "$focus_file" ]]; then
+        hyprctl dispatch focuswindow "address:$(cat "$focus_file")"
+        rm -f "$focus_file"
+    fi
     rm -f "$state_file"
 else
+    # Save currently focused window
+    active_window=$(hyprctl activewindow -j | jq -r '.address')
+
     # Hide all windows to special workspace
     windows=$(hyprctl clients -j | jq -r --argjson ws "$current_workspace" '.[] | select(.workspace.id == $ws) | .address')
     if [[ -n "$windows" ]]; then
+        [[ "$active_window" != "null" ]] && echo "$active_window" > "$focus_file"
         echo "$windows" > "$state_file"
         echo "$windows" | while IFS= read -r addr; do
             hyprctl dispatch movetoworkspacesilent "special:desktop,address:$addr"

--- a/home/modules/hyprland/omarchy-scripts.nix
+++ b/home/modules/hyprland/omarchy-scripts.nix
@@ -16,5 +16,6 @@ in
     (mkScript "omarchy-restart-mako" ../../../bin/omarchy/restart-mako)
     (mkScript "omarchy-menu" ../../../bin/omarchy/menu)
     (mkScript "omarchy-super-launcher" ../../../bin/omarchy/super-launcher)
+    (mkScript "omarchy-show-desktop" ../../../bin/omarchy/show-desktop)
   ];
 }


### PR DESCRIPTION
## Summary
- Add `omarchy-show-desktop` script that toggles "show desktop" by moving all windows to/from a special workspace
- Replace Super+D fuzzel launcher with show desktop toggle (Super alone already launches fuzzel)
- Track state per workspace for proper multi-monitor support

## Test plan
- [ ] Press Super+D to hide all windows on current workspace
- [ ] Press Super+D again to restore windows
- [ ] Verify Super alone still opens fuzzel launcher
- [ ] Test on multiple workspaces to verify per-workspace state