### PR TITLE
fix(theme): integrate components with omarchy theme system

### DIFF
--- a/.config/fuzzel/fuzzel.ini
+++ b/.config/fuzzel/fuzzel.ini
@@ -29,15 +29,6 @@ terminal=wezterm
 # layer = top
 # exit-on-keyboard-focus-loss = yes
 
-# Catppuccin Mocha Theme Blue
-[colors]
-background=1e1e2edd
-text=cdd6f4ff
-match=89b4faff
-selection=585b70ff
-selection-text=cdd6f4ff
-selection-match=89b4faff
-border=89b4faff
 
 [border]
 # width=2

--- a/.config/omarchy/themed/fuzzel.ini.tpl
+++ b/.config/omarchy/themed/fuzzel.ini.tpl
@@ -1,0 +1,8 @@
+[colors]
+background={{ background_strip }}dd
+text={{ foreground_strip }}ff
+match={{ accent_strip }}ff
+selection={{ color8_strip }}ff
+selection-text={{ foreground_strip }}ff
+selection-match={{ accent_strip }}ff
+border={{ accent_strip }}ff

--- a/.config/omarchy/themed/hyprshell.css.tpl
+++ b/.config/omarchy/themed/hyprshell.css.tpl
@@ -1,0 +1,12 @@
+* {
+    --text-color: {{ foreground }};
+    --bg-color: {{ background }};
+    --bg-color-hover: {{ selection_background }};
+    --bg-window-color: {{ background }};
+    --border-color: {{ accent }};
+    --border-color-active: {{ foreground }};
+}
+
+.monitor {
+    border: none;
+}

--- a/.config/omarchy/themed/waybar.css.tpl
+++ b/.config/omarchy/themed/waybar.css.tpl
@@ -3,3 +3,7 @@
 @define-color accent {{ accent }};
 @define-color dim {{ color8 }};
 @define-color surface {{ selection_background }};
+@define-color primary {{ color4 }};
+@define-color secondary {{ color5 }};
+@define-color warning {{ color3 }};
+@define-color error {{ color1 }};

--- a/.config/waybar/calendar-popup.py
+++ b/.config/waybar/calendar-popup.py
@@ -4,6 +4,27 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gdk
 import subprocess
 import json
+import os
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+
+def load_theme_colors():
+    colors_path = os.path.expanduser("~/.config/omarchy/current/theme/colors.toml")
+    defaults = {
+        "background": "#1e1e2e",
+        "foreground": "#cdd6f4",
+        "color4": "#89b4fa",
+        "color6": "#94e2d5",
+        "color8": "#6c7086",
+    }
+    try:
+        with open(colors_path, "rb") as f:
+            colors = tomllib.load(f)
+            return {**defaults, **colors}
+    except:
+        return defaults
 
 class CalendarWindow(Gtk.Window):
     def __init__(self):
@@ -30,53 +51,63 @@ class CalendarWindow(Gtk.Window):
         # Close on escape
         self.connect("key-press-event", self.on_key_press)
 
+        # Load theme colors
+        c = load_theme_colors()
+
         # Style
-        css = b"""
-        window {
-            background-color: #1e1e2e;
+        css = f"""
+        window {{
+            background-color: {c['background']};
             border-radius: 12px;
             border: none;
-        }
-        calendar {
-            background-color: #1e1e2e;
-            color: #cdd6f4;
+        }}
+        calendar {{
+            background-color: {c['background']};
+            color: {c['foreground']};
             font-size: 18px;
             padding: 12px;
             border: none;
-        }
-        calendar.header {
+        }}
+        calendar.header {{
             border: none;
-            background-color: #1e1e2e;
-        }
-        calendar:selected {
-            background-color: #94e2d5;
-            color: #1e1e2e;
-        }
-        calendar.header {
-            color: #cdd6f4;
+            background-color: {c['background']};
+        }}
+        calendar:selected {{
+            background-color: {c['accent']};
+            color: {c['background']};
+        }}
+        calendar.header {{
+            color: {c['foreground']};
             font-weight: bold;
             font-size: 20px;
-        }
-        calendar.button {
-            color: #89b4fa;
-        }
-        calendar:indeterminate {
-            color: #6c7086;
-        }
-        button.close {
-            background-color: #94e2d5;
+        }}
+        calendar.button {{
+            color: {c['color4']};
+        }}
+        calendar:indeterminate {{
+            color: {c['color8']};
+        }}
+        button.close {{
+            background: {c['accent']};
+            background-color: {c['accent']};
+            background-image: none;
             border: none;
             border-radius: 6px;
-            color: #1e1e2e;
-            padding: 2px 8px;
+            color: {c['background']};
+            padding: 4px 10px;
             min-width: 0;
             min-height: 0;
             font-weight: bold;
-        }
-        button.close:hover {
-            background-color: #89b4fa;
-        }
-        """
+        }}
+        button.close label {{
+            color: {c['background']};
+        }}
+        button.close:hover {{
+            background: {c['color4']};
+            background-color: {c['color4']};
+            background-image: none;
+        }}
+        """.encode()
         style_provider = Gtk.CssProvider()
         style_provider.load_from_data(css)
         Gtk.StyleContext.add_provider_for_screen(

--- a/.config/waybar/style.css.in
+++ b/.config/waybar/style.css.in
@@ -1,5 +1,5 @@
-/* Import theme colors - fallback to empty if theme not set */
-@import url("waybar-theme.css");
+/* Import theme colors from omarchy theme system */
+@import url("@HOME@/.config/omarchy/current/theme/waybar.css");
 
 * {
   background-color: @background;

--- a/bin/omarchy/bluetooth
+++ b/bin/omarchy/bluetooth
@@ -5,7 +5,7 @@ menu() {
   local options="$2"
   local lines="${3:-5}"
 
-  echo -e "$options" | fuzzel --dmenu --width 30 --lines "$lines" --prompt "$prompt> " 2>/dev/null
+  echo -e "$options" | omarchy-fuzzel --dmenu --width 30 --lines "$lines" --prompt "$prompt> " 2>/dev/null
 }
 
 get_power_status() {

--- a/bin/omarchy/fuzzel
+++ b/bin/omarchy/fuzzel
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Wrapper for fuzzel that merges base config with theme colors
+
+BASE_CONFIG="$HOME/.config/fuzzel/fuzzel.ini"
+THEME_COLORS="$HOME/.config/omarchy/current/theme/fuzzel.ini"
+MERGED_CONFIG="$HOME/.cache/omarchy/fuzzel-merged.ini"
+
+mkdir -p "$(dirname "$MERGED_CONFIG")"
+
+if [[ -f "$THEME_COLORS" ]]; then
+  { cat "$BASE_CONFIG"; echo ""; cat "$THEME_COLORS"; } > "$MERGED_CONFIG"
+  exec /usr/bin/env fuzzel --config="$MERGED_CONFIG" "$@"
+else
+  exec /usr/bin/env fuzzel "$@"
+fi

--- a/bin/omarchy/menu
+++ b/bin/omarchy/menu
@@ -30,7 +30,7 @@ menu() {
     fi
   fi
 
-  echo -e "$options" | fuzzel --dmenu --width 30 --lines 10 --prompt "$prompt> " 2>/dev/null
+  echo -e "$options" | omarchy-fuzzel --dmenu --width 30 --lines 10 --prompt "$prompt> " 2>/dev/null
 }
 
 show_theme_menu() {
@@ -65,7 +65,7 @@ show_main_menu() {
 
 go_to_menu() {
   case "${1,,}" in
-  *apps*) fuzzel ;;
+  *apps*) omarchy-fuzzel ;;
   *style*) show_style_menu ;;
   *theme*) show_theme_menu ;;
   *system*) show_system_menu ;;

--- a/bin/omarchy/super-launcher
+++ b/bin/omarchy/super-launcher
@@ -29,7 +29,7 @@ fi
 # Get window count before fuzzel
 windows_before=$(hyprctl clients -j | jq 'length')
 
-fuzzel
+omarchy-fuzzel
 
 # Small delay to let any launched app create its window
 sleep 0.15

--- a/bin/omarchy/theme-set
+++ b/bin/omarchy/theme-set
@@ -42,6 +42,11 @@ omarchy-restart-swayosd
 omarchy-restart-hyprctl
 omarchy-restart-mako
 
+# Restart hyprshell if running (reloads CSS)
+if pgrep -x hyprshell >/dev/null; then
+  systemctl --user restart hyprshell.service 2>/dev/null || true
+fi
+
 omarchy-theme-set-gnome
 
 notify-send "Theme changed" "$THEME_NAME" -t 2000

--- a/home/modules/hyprland/hyprland.nix
+++ b/home/modules/hyprland/hyprland.nix
@@ -1,4 +1,9 @@
-{ pkgs, inputs, ... }:
+{
+  pkgs,
+  inputs,
+  config,
+  ...
+}:
 let
   isNixOS = builtins.pathExists /etc/NIXOS;
   hyprlandFlake = inputs.hyprland.packages.${pkgs.stdenv.hostPlatform.system}.hyprland;
@@ -49,7 +54,17 @@ in
 
     file = {
       ".config/hypr".source = ../../../.config/hypr;
-      ".config/waybar".source = ../../../.config/waybar;
+
+      # Waybar config - individual files so we can template style.css
+      ".config/waybar/config".source = ../../../.config/waybar/config;
+      ".config/waybar/nix.svg".source = ../../../.config/waybar/nix.svg;
+      ".config/waybar/calendar-popup.py".source = ../../../.config/waybar/calendar-popup.py;
+      ".config/waybar/calendar-toggle.sh".source = ../../../.config/waybar/calendar-toggle.sh;
+      ".config/waybar/waybar-theme.css".source = ../../../.config/waybar/waybar-theme.css;
+      # style.css with dynamic home directory path
+      ".config/waybar/style.css".text =
+        builtins.replaceStrings [ "@HOME@" ] [ config.home.homeDirectory ]
+          (builtins.readFile ../../../.config/waybar/style.css.in);
 
       # Omarchy theme system - symlink read-only parts, let 'current' be runtime-writable
       ".config/omarchy/themes".source = ../../../.config/omarchy/themes;

--- a/home/modules/hyprland/hyprshell.nix
+++ b/home/modules/hyprland/hyprshell.nix
@@ -1,4 +1,9 @@
-{ pkgs, inputs, ... }:
+{
+  pkgs,
+  inputs,
+  config,
+  ...
+}:
 {
   imports = [ inputs.hyprshell.homeModules.hyprshell ];
 
@@ -11,6 +16,11 @@
       enable = true;
       target = "hyprland-session.target";
     };
+
+    # Use dynamic theme CSS from omarchy theme system via @import
+    styleFile = ''
+      @import url("${config.home.homeDirectory}/.config/omarchy/current/theme/hyprshell.css");
+    '';
 
     settings = {
       windows = {

--- a/home/modules/hyprland/omarchy-scripts.nix
+++ b/home/modules/hyprland/omarchy-scripts.nix
@@ -15,6 +15,7 @@ in
     (mkScript "omarchy-restart-hyprctl" ../../../bin/omarchy/restart-hyprctl)
     (mkScript "omarchy-restart-mako" ../../../bin/omarchy/restart-mako)
     (mkScript "omarchy-menu" ../../../bin/omarchy/menu)
+    (mkScript "omarchy-fuzzel" ../../../bin/omarchy/fuzzel)
     (mkScript "omarchy-super-launcher" ../../../bin/omarchy/super-launcher)
     (mkScript "omarchy-bluetooth" ../../../bin/omarchy/bluetooth)
     (mkScript "omarchy-close-window-cycle" ../../../bin/omarchy/close-window-cycle)


### PR DESCRIPTION
## Summary
- Enable dynamic theme switching for waybar, calendar popup, fuzzel, and hyprshell window switcher
- All components now update when using `SUPER+SHIFT+CTRL+SPACE` to change themes

## Changes

### Waybar
- Import colors from generated theme file instead of static CSS
- Use `style.css.in` template with `@HOME@` placeholder for portable paths
- Add missing color variables (primary, secondary, warning, error)

### Calendar popup
- Read colors from `~/.config/omarchy/current/theme/colors.toml` at runtime
- Remove hardcoded catppuccin colors

### Fuzzel (bluetooth menu)
- Create `omarchy-fuzzel` wrapper that merges base config with theme colors
- Create `fuzzel.ini.tpl` template for color generation
- Update bluetooth, menu, and super-launcher to use the wrapper

### Hyprshell (window switcher)
- Create `hyprshell.css.tpl` template with CSS variables
- Configure home-manager to use generated stylesheet
- Add hyprshell service restart to theme-set script

## Test plan
- [x] Rebuild from worktree
- [x] Theme files generated correctly
- [x] Theme switching updates all components
- [ ] Visual verification by user