### PR TITLE
feat(hyprland): maximize workflow to eliminate resize jank

### DIFF
--- a/docs/plans/hyprland-maximize-workflow.md
+++ b/docs/plans/hyprland-maximize-workflow.md
@@ -1,0 +1,71 @@
+# Hyprland Maximize Workflow
+
+## Problem
+
+When using Super+Tab (hyprshell window switcher), windows lose their maximized state and revert to tiled layout. This causes apps to resize themselves, creating a janky user experience.
+
+**Current behavior:**
+1. Window A is maximized (Super+F, `fullscreen 1`)
+2. Super+Tab to Window B
+3. Window A loses maximize state, returns to tiled
+4. When switching back, Window A needs to resize again
+
+## Proposed Solutions
+
+### Option 1: Window Rule (Simple but incomplete)
+```conf
+windowrulev2 = maximize, class:.*
+```
+- All new windows start maximized
+- Does NOT preserve maximize on focus change
+- Same resize problem persists
+
+### Option 2: One-window-per-workspace (GNOME-like)
+Put each app in its own workspace. Navigate workspaces instead of windows.
+- Clean, each app always has full screen
+- No resize jank since window is always alone in workspace
+- Changes mental model, more workspaces to manage
+- Super+Tab becomes workspace switch
+
+### Option 3: IPC Daemon Auto-Maximize (Recommended)
+A systemd user service listening to Hyprland's `activewindow` event that immediately maximizes the focused window:
+
+```bash
+#!/usr/bin/env bash
+socat -U - UNIX-CONNECT:$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock | while read -r line; do
+  if [[ "$line" =~ ^activewindow ]]; then
+    hyprctl dispatch fullscreen 1
+  fi
+done
+```
+
+- Keeps current workflow with hyprshell visual preview
+- Windows always maximized on focus
+- Slight visual flash during maximize transition
+- Requires systemd service management
+
+### Option 4: Custom Super+Tab Script
+Replace hyprshell's switcher with a script that switches AND maximizes atomically.
+- Precise control over behavior
+- Loses hyprshell's visual preview feature
+
+### Option 5: Special Workspace Stacking
+Move unfocused windows to a special workspace, pull focused one to current workspace.
+- True single-window view (only one tiled = full size)
+- Complex implementation
+- May break window focus history
+
+## Recommendation
+
+**Option 3 (IPC Daemon)** provides the smoothest experience:
+- Preserves hyprshell visual preview on Super+Tab
+- Every window auto-maximizes on focus
+- Minimal config changes
+- Can be toggled via systemd
+
+## Implementation Plan
+
+1. Create `omarchy-maximize-daemon` script in `home/modules/hyprland/omarchy-scripts.nix`
+2. Add systemd user service to start daemon with Hyprland session
+3. Update user bindings if needed
+4. Test with various apps (terminals, browsers, editors)


### PR DESCRIPTION
## Summary
- Add plan document exploring solutions for window resize jank when switching between maximized windows
- Current Super+F maximize + Super+Tab switching causes windows to lose maximize state and resize

## Proposed Approaches
1. **Window Rule** - Simple `maximize` rule (incomplete fix)
2. **One-window-per-workspace** - GNOME-like model
3. **IPC Daemon** (Recommended) - Auto-maximize on focus change
4. **Custom Super+Tab** - Replace hyprshell with custom script
5. **Special Workspace Stacking** - Move unfocused windows away

## Recommendation
Option 3 (IPC Daemon) - keeps hyprshell visual preview while ensuring all windows are maximized on focus.

## Test plan
- [ ] Review plan and choose approach
- [ ] Implement chosen solution
- [ ] Test with wezterm, brave, vscode
- [ ] Verify no resize jank on Super+Tab