### PR TITLE
feat(hyprland): maintain maximized state when windows self-close

### DIFF
--- a/.config/hypr/user/autostart.conf
+++ b/.config/hypr/user/autostart.conf
@@ -9,3 +9,6 @@ exec-once = hyprctl dispatch workspace 11
 
 # Start a terminal
 exec-once = wezterm
+
+# Maximize focus daemon - maintains maximized state when windows self-close
+exec-once = omarchy-maximize-focus-daemon

--- a/bin/omarchy/maximize-focus-daemon
+++ b/bin/omarchy/maximize-focus-daemon
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Daemon that maintains maximized state when windows self-close
+# When a maximized window closes, the newly focused window gets maximized
+
+SOCKET="$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock"
+
+get_active_fullscreen() {
+  hyprctl activewindow -j 2>/dev/null | jq -r '.fullscreen // 0'
+}
+
+get_workspace_hasfullscreen() {
+  local ws_id="$1"
+  hyprctl workspaces -j 2>/dev/null | jq -r --arg ws "$ws_id" '.[] | select(.id == ($ws | tonumber)) | .hasfullscreen'
+}
+
+get_active_workspace() {
+  hyprctl activewindow -j 2>/dev/null | jq -r '.workspace.id // empty'
+}
+
+maximized_workspaces=()
+
+is_workspace_tracked() {
+  local ws="$1"
+  for tracked in "${maximized_workspaces[@]}"; do
+    [[ "$tracked" == "$ws" ]] && return 0
+  done
+  return 1
+}
+
+add_workspace() {
+  local ws="$1"
+  if ! is_workspace_tracked "$ws"; then
+    maximized_workspaces+=("$ws")
+  fi
+}
+
+remove_workspace() {
+  local ws="$1"
+  local new_array=()
+  for tracked in "${maximized_workspaces[@]}"; do
+    [[ "$tracked" != "$ws" ]] && new_array+=("$tracked")
+  done
+  maximized_workspaces=("${new_array[@]}")
+}
+
+handle_event() {
+  local event="$1"
+  local data="$2"
+
+  case "$event" in
+    fullscreen)
+      # fullscreen>>0 or fullscreen>>1 (1 = maximized mode entered)
+      if [[ "$data" == "1" ]]; then
+        local ws
+        ws=$(get_active_workspace)
+        [[ -n "$ws" ]] && add_workspace "$ws"
+      fi
+      ;;
+    closewindow)
+      # Small delay to let Hyprland update focus
+      sleep 0.05
+      local ws
+      ws=$(get_active_workspace)
+      if [[ -n "$ws" ]] && is_workspace_tracked "$ws"; then
+        local current_fullscreen
+        current_fullscreen=$(get_active_fullscreen)
+        # If workspace was tracked as maximized but current window isn't maximized
+        if [[ "$current_fullscreen" != "1" ]]; then
+          # Check if there's still a window to maximize
+          local window_count
+          window_count=$(hyprctl clients -j 2>/dev/null | jq --arg ws "$ws" '[.[] | select(.workspace.id == ($ws | tonumber))] | length')
+          if [[ "$window_count" -gt 0 ]]; then
+            hyprctl dispatch fullscreen 1
+          else
+            # No windows left, stop tracking
+            remove_workspace "$ws"
+          fi
+        fi
+      fi
+      ;;
+    workspace)
+      # When switching workspaces, we don't need to do anything special
+      # The tracking persists
+      ;;
+  esac
+}
+
+# Initial scan: track workspaces that already have maximized windows
+while IFS= read -r ws_id; do
+  if [[ "$(get_workspace_hasfullscreen "$ws_id")" == "true" ]]; then
+    add_workspace "$ws_id"
+  fi
+done < <(hyprctl workspaces -j | jq -r '.[].id')
+
+# Listen for events
+while IFS= read -r line; do
+  event="${line%%>>*}"
+  data="${line#*>>}"
+  handle_event "$event" "$data"
+done < <(nc -U "$SOCKET")

--- a/home/modules/hyprland/omarchy-scripts.nix
+++ b/home/modules/hyprland/omarchy-scripts.nix
@@ -20,5 +20,6 @@ in
     (mkScript "omarchy-bluetooth" ../../../bin/omarchy/bluetooth)
     (mkScript "omarchy-close-window-cycle" ../../../bin/omarchy/close-window-cycle)
     (mkScript "omarchy-show-desktop" ../../../bin/omarchy/show-desktop)
+    (mkScript "omarchy-maximize-focus-daemon" ../../../bin/omarchy/maximize-focus-daemon)
   ];
 }


### PR DESCRIPTION
## Summary
- Adds `omarchy-maximize-focus-daemon` that listens to Hyprland IPC events
- When a maximized window closes itself (clicking X, app quit), the daemon detects this and maximizes the newly focused window
- Maintains workspace maximize state automatically

## Test plan
- [ ] Rebuild: `./bin/rebuild`
- [ ] Start daemon: `omarchy-maximize-focus-daemon &` (or relog for autostart)
- [ ] Maximize a window with Super+F
- [ ] Close window by clicking X or app quit
- [ ] Verify the next focused window becomes maximized