### PR TITLE
fix(theme): atomic swap to prevent hyprland auto-reload race condition

### DIFF
--- a/bin/omarchy/theme-set
+++ b/bin/omarchy/theme-set
@@ -28,8 +28,11 @@ cp -rL --no-preserve=mode "$THEME_PATH/"* "$NEXT_THEME_PATH/" 2>/dev/null
 
 omarchy-theme-set-templates
 
-rm -rf "$CURRENT_THEME_PATH"
+OLD_THEME_PATH="$HOME/.config/omarchy/current/old-theme"
+rm -rf "$OLD_THEME_PATH"
+mv "$CURRENT_THEME_PATH" "$OLD_THEME_PATH" 2>/dev/null || true
 mv "$NEXT_THEME_PATH" "$CURRENT_THEME_PATH"
+rm -rf "$OLD_THEME_PATH"
 
 echo "$THEME_NAME" > "$HOME/.config/omarchy/current/theme.name"
 


### PR DESCRIPTION
## Summary
- Replace `rm -rf` + `mv` with atomic swap pattern (mv-to-backup + mv + cleanup)
- Prevents Hyprland's auto-reload (inotify) from triggering between rm and mv operations
- Fixes "globbing error: found no match" error flash on first theme application

## Root Cause
Hyprland has `misc:disable_autoreload = 0` (auto-reload enabled). When `rm -rf` deleted the theme directory, inotify triggered a config reload *before* `mv` could create the new directory, causing `source = ~/.config/omarchy/current/theme/hyprland.conf` to fail.

## Test plan
- [x] Switch themes multiple times with fixed script
- [x] Verify no error flash appears
- [ ] User manual test with Super+Shift+Ctrl+Space keybinding