### PR TITLE
feat(hyprland): convert waybar, hypridle, mako to systemd services

### DIFF
--- a/.config/hypr/hypridle.conf
+++ b/.config/hypr/hypridle.conf
@@ -1,0 +1,23 @@
+general {
+    lock_cmd = pidof hyprlock || hyprlock
+    before_sleep_cmd = loginctl lock-session
+    after_sleep_cmd = hyprctl dispatch dpms on
+    ignore_dbus_inhibit = false
+    ignore_systemd_inhibit = false
+}
+
+listener {
+    timeout = 300
+    on-timeout = hyprctl dispatch dpms off
+    on-resume = hyprctl dispatch dpms on
+}
+
+listener {
+    timeout = 600
+    on-timeout = loginctl lock-session
+}
+
+listener {
+    timeout = 900
+    on-timeout = systemctl suspend
+}

--- a/.config/hypr/omarchy/autostart.conf
+++ b/.config/hypr/omarchy/autostart.conf
@@ -1,7 +1,4 @@
 exec-once = gnome-keyring-daemon --start --components=secrets
-exec-once = hypridle
-exec-once = omarchy-restart-mako
-exec-once = waybar
 exec-once = swaybg -i ~/.config/omarchy/current/background -m fill || swaybg --color '#000000'
 exec-once = wl-paste --type text --watch cliphist store
 exec-once = wl-paste --type image --watch cliphist store

--- a/home/modules/hyprland/default.nix
+++ b/home/modules/hyprland/default.nix
@@ -10,6 +10,9 @@
     ./hyprshell.nix
     ./wlogout.nix
     ./swayosd.nix
+    ./waybar-service.nix
+    ./hypridle-service.nix
+    ./mako-service.nix
     ../fuzzel.nix
   ];
 }

--- a/home/modules/hyprland/hypridle-service.nix
+++ b/home/modules/hyprland/hypridle-service.nix
@@ -1,0 +1,22 @@
+{ pkgs, ... }:
+{
+  systemd.user.services.hypridle = {
+    Unit = {
+      Description = "Hyprland idle daemon";
+      Documentation = "https://github.com/hyprwm/hypridle";
+      PartOf = [ "graphical-session.target" ];
+      After = [ "graphical-session.target" ];
+    };
+
+    Service = {
+      Type = "simple";
+      ExecStart = "${pkgs.hypridle}/bin/hypridle";
+      Restart = "always";
+      RestartSec = "1s";
+    };
+
+    Install = {
+      WantedBy = [ "graphical-session.target" ];
+    };
+  };
+}

--- a/home/modules/hyprland/mako-service.nix
+++ b/home/modules/hyprland/mako-service.nix
@@ -1,0 +1,38 @@
+{ pkgs, ... }:
+let
+  makoStart = pkgs.writeShellScript "mako-start" ''
+    BASE_CONFIG="$HOME/.config/mako/config"
+    THEME_COLORS="$HOME/.config/omarchy/current/theme/mako.ini"
+    MERGED_CONFIG="$HOME/.cache/omarchy/mako-merged.ini"
+
+    mkdir -p "$(dirname "$MERGED_CONFIG")"
+
+    if [[ -f "$THEME_COLORS" ]]; then
+      { cat "$BASE_CONFIG"; echo ""; cat "$THEME_COLORS"; } > "$MERGED_CONFIG"
+      exec ${pkgs.mako}/bin/mako -c "$MERGED_CONFIG"
+    else
+      exec ${pkgs.mako}/bin/mako -c "$BASE_CONFIG"
+    fi
+  '';
+in
+{
+  systemd.user.services.mako = {
+    Unit = {
+      Description = "Mako notification daemon";
+      Documentation = "https://github.com/emersion/mako";
+      PartOf = [ "graphical-session.target" ];
+      After = [ "graphical-session.target" ];
+    };
+
+    Service = {
+      Type = "simple";
+      ExecStart = "${makoStart}";
+      Restart = "always";
+      RestartSec = "1s";
+    };
+
+    Install = {
+      WantedBy = [ "graphical-session.target" ];
+    };
+  };
+}

--- a/home/modules/hyprland/waybar-service.nix
+++ b/home/modules/hyprland/waybar-service.nix
@@ -1,0 +1,22 @@
+{ pkgs, ... }:
+{
+  systemd.user.services.waybar = {
+    Unit = {
+      Description = "Waybar status bar";
+      Documentation = "https://github.com/Alexays/Waybar";
+      PartOf = [ "graphical-session.target" ];
+      After = [ "graphical-session.target" ];
+    };
+
+    Service = {
+      Type = "simple";
+      ExecStart = "${pkgs.waybar}/bin/waybar";
+      Restart = "always";
+      RestartSec = "1s";
+    };
+
+    Install = {
+      WantedBy = [ "graphical-session.target" ];
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- Convert waybar, hypridle, and mako from exec-once to systemd user services
- These processes now auto-restart on crash and after nix rebuilds

## Problem
Processes started via `exec-once` in Hyprland's autostart.conf don't restart when:
- They crash
- Nix rebuild changes their store paths (kills the old process)

This caused waybar workspace indicator and notifications to break after rebuilds.

## Solution
Convert to systemd user services following the pattern from `swayosd.nix`:
- `waybar-service.nix` - Status bar
- `hypridle-service.nix` - Idle daemon  
- `mako-service.nix` - Notification daemon (with config merging)

All services:
- Use `Restart=always` for crash recovery
- Depend on `graphical-session.target`
- Get proper logging via `journalctl --user -u <service>`

## Test plan
- [ ] Rebuild and verify services start: `systemctl --user status waybar hypridle mako`
- [ ] Kill waybar and verify it restarts: `pkill waybar && sleep 2 && pgrep waybar`
- [ ] Test notifications still work with theming
- [ ] Test workspace indicator updates on workspace switch