### PR TITLE
fix(hyprland): isolate swaync GIO modules to prevent CPU spin

### DIFF
--- a/home/modules/hyprland/swaync-service.nix
+++ b/home/modules/hyprland/swaync-service.nix
@@ -25,6 +25,11 @@ in
       ExecStart = "${swayncStart}";
       Restart = "always";
       RestartSec = "1s";
+      # Isolate GIO modules to prevent loading incompatible system libraries
+      # Fixes CPU spin from GLIBC version mismatch with gvfs/dconf modules
+      Environment = [
+        "GIO_MODULE_DIR=${pkgs.glib-networking}/lib/gio/modules"
+      ];
     };
 
     Install = {


### PR DESCRIPTION
## Summary
- Set `GIO_MODULE_DIR` environment variable in swaync systemd service to use Nix-provided glib-networking modules
- Prevents swaync from loading incompatible system GTK/GIO libraries (gvfs, dconf)
- Fixes 100%+ CPU usage caused by GLIBC version mismatch errors being logged in a tight loop

## Problem
The swaync service was consuming excessive CPU (101% constantly) because it was stuck in a loop trying to load GTK/GIO modules with library incompatibilities:
1. GLIBC version mismatch - gvfs module requires GLIBC 2.38 but system has older version
2. Missing symbols - dconf module has undefined symbols (g_assertion_message_cmpint)

These errors occurred every few seconds as swaync constantly retried loading the modules.

## Solution
Isolate swaync's GIO module path by setting `GIO_MODULE_DIR` to point only to Nix-provided `glib-networking` modules, preventing the service from attempting to load incompatible system libraries.

## Test plan
- [x] Rebuild home-manager configuration
- [x] Verify swaync service starts without errors
- [x] Verify CPU usage is normal (~0% idle, not 100%+)
- [x] Verify `GIO_MODULE_DIR` is set correctly in generated service file