### PR TITLE
feat(openclaw): agent resilience — survive gateway restarts

### DIFF
--- a/agents/core.md
+++ b/agents/core.md
@@ -60,25 +60,6 @@ Understand contextually. User prompts may contain errors - interpret intent, cor
 Be direct and technical. Concise answers. If user is wrong, tell them. If build fails, fix immediately - don't just report. Verify tests pass before marking complete.
 </communication>
 
-<work-in-progress-persistence>
-The gateway may restart at any time (system rebuilds, updates, crashes). Active sessions are lost on restart. To survive restarts, persist work-in-progress state to HEARTBEAT.md.
-
-When starting multi-step or long-running work:
-1. Write a task entry to HEARTBEAT.md describing the current objective, progress, and next steps.
-2. Update the entry as you make progress (completed steps, remaining steps, blockers).
-3. Remove the entry only when the work is fully complete and delivered to the user.
-
-HEARTBEAT.md format for work-in-progress:
-```
-## Active Work
-- [task-id] Short description of work
-  Status: in-progress | blocked | awaiting-review
-  Progress: what's done so far
-  Next: immediate next step
-  Context: branch name, file paths, PR URLs, or other resumption context
-```
-
-On heartbeat, if you find active work entries you wrote, resume from where you left off. Read the context, assess current state, and continue. If the work is stale (>24h), notify the user and ask whether to continue or discard.
-
-This is NOT optional for multi-step work. Single-turn responses don't need persistence.
-</work-in-progress-persistence>
+<session-resilience>
+Sessions die on gateway restarts. Multi-step work survives only if persisted. Before starting long-running or multi-step work, write current objective and next steps to HEARTBEAT.md. Update as you progress. Remove when delivered. On heartbeat, resume any active entries you find. Stale entries (>24h) get reported to user, not silently resumed.
+</session-resilience>

--- a/agents/core.md
+++ b/agents/core.md
@@ -59,3 +59,26 @@ Understand contextually. User prompts may contain errors - interpret intent, cor
 <communication>
 Be direct and technical. Concise answers. If user is wrong, tell them. If build fails, fix immediately - don't just report. Verify tests pass before marking complete.
 </communication>
+
+<work-in-progress-persistence>
+The gateway may restart at any time (system rebuilds, updates, crashes). Active sessions are lost on restart. To survive restarts, persist work-in-progress state to HEARTBEAT.md.
+
+When starting multi-step or long-running work:
+1. Write a task entry to HEARTBEAT.md describing the current objective, progress, and next steps.
+2. Update the entry as you make progress (completed steps, remaining steps, blockers).
+3. Remove the entry only when the work is fully complete and delivered to the user.
+
+HEARTBEAT.md format for work-in-progress:
+```
+## Active Work
+- [task-id] Short description of work
+  Status: in-progress | blocked | awaiting-review
+  Progress: what's done so far
+  Next: immediate next step
+  Context: branch name, file paths, PR URLs, or other resumption context
+```
+
+On heartbeat, if you find active work entries you wrote, resume from where you left off. Read the context, assess current state, and continue. If the work is stale (>24h), notify the user and ask whether to continue or discard.
+
+This is NOT optional for multi-step work. Single-turn responses don't need persistence.
+</work-in-progress-persistence>

--- a/home/modules/openclaw/config-declarations.nix
+++ b/home/modules/openclaw/config-declarations.nix
@@ -135,6 +135,7 @@ let
     ".tools.exec.notifyOnExit" = true;
     ".gateway.port" = openclaw.gatewayPort;
     ".gateway.mode" = "local";
+    ".gateway.reload.mode" = "hybrid";
     ".gateway.http.endpoints.chatCompletions.enabled" = true;
     ".channels.telegram.commands.nativeSkills" = false;
   };

--- a/home/modules/openclaw/config-engine.nix
+++ b/home/modules/openclaw/config-engine.nix
@@ -163,10 +163,6 @@ let
 
     if [ "$HASH_BEFORE" != "$HASH_AFTER" ]; then
       sync
-      export XDG_RUNTIME_DIR="''${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
-      if ${pkgs.systemd}/bin/systemctl --user is-active openclaw-gateway.service >/dev/null 2>&1; then
-        ${pkgs.systemd}/bin/systemctl --user restart openclaw-gateway.service || true
-      fi
     fi
   '';
 in


### PR DESCRIPTION
## Problem

Every system rebuild (`~/.dotfiles/bin/rebuild`) triggers `systemctl --user restart openclaw-gateway.service` in the config-engine activation script. This kills all active agent sessions mid-work. Agents lose their progress and must be manually re-triggered.

## Root Cause

The `config-engine.nix` activation script does a hard gateway restart whenever `openclaw.json` changes — even though the gateway already supports hot-reload via file watching (`gateway.reload.mode=hybrid` is the default).

## Solution

### 1. Remove hard restart from config-engine (structural fix)

The activation script now only writes and syncs the config file. The gateway's own file watcher detects the change and hot-reloads safe changes (agent config, model settings, bindings) without dropping sessions. For changes that require a full restart (port changes, auth changes), the gateway's hybrid mode handles that automatically.

**Before:** rebuild → config patch → `systemctl restart` → all sessions killed
**After:** rebuild → config patch → `sync` → gateway hot-reloads → sessions survive

### 2. Explicit `gateway.reload.mode=hybrid` in declarations

Set explicitly in config-declarations.nix for clarity and auditability, even though it's the default.

### 3. Work-in-progress persistence rules in core agent instructions (convention fix)

Added `<work-in-progress-persistence>` section to `agents/core.md`. Agents must:
- Write multi-step work state to `HEARTBEAT.md` before starting
- Update progress as they go
- On heartbeat, resume any unfinished work found
- Clean up entries when work is complete

This covers the cases where a restart IS unavoidable (crashes, major config changes, system updates).

## Testing

- [x] `nix build` succeeds for `homeConfigurations.lucas.zanoni@x86_64-linux`
- [x] Generated activation script contains zero `systemctl restart openclaw` calls
- [x] Gateway hot-reload confirmed: config touch → PID unchanged, logs show `[reload] config change applied`
- [x] NixOS watchdog (`openclaw-watchdog.nix`) unaffected — it only restarts on actual health check failure

## Files Changed

- `home/modules/openclaw/config-engine.nix` — removed hard restart, kept sync
- `home/modules/openclaw/config-declarations.nix` — added `gateway.reload.mode=hybrid`
- `agents/core.md` — added work-in-progress persistence rules