### PR TITLE
feat(openclaw): add Ollama provider with GLM-4 and Llama 3.2

### DIFF
--- a/users/lucas.zanoni/home/openclaw.nix
+++ b/users/lucas.zanoni/home/openclaw.nix
@@ -9,6 +9,8 @@ let
   opusModel = "anthropic/claude-opus-4-6";
   sonnetModel = "anthropic/claude-sonnet-4-6";
   codexModel = "openai-codex/gpt-5.3-codex";
+  glmModel = "ollama/glm4";
+  llamaModel = "ollama/llama3.2";
 
   robsonModelPrimary = opusModel;
   jennyModelPrimary = sonnetModel;
@@ -25,6 +27,30 @@ in
   openclaw = {
     configPatches = {
       ".channels.discord.accounts.robson.guilds.${robsonDiscordGuildId}.users" = [ lucasDiscordUserId ];
+
+      # Ollama — local inference provider
+      ".models.providers.ollama" = {
+        baseUrl = "http://localhost:11434";
+        api = "ollama";
+        models = [
+          {
+            id = "glm4";
+            name = "GLM-4 (local)";
+            contextWindow = 131072;
+            maxTokens = 8192;
+          }
+          {
+            id = "llama3.2";
+            name = "Llama 3.2 (local)";
+            contextWindow = 131072;
+            maxTokens = 8192;
+          }
+        ];
+      };
+
+      # Model aliases for quick /model switching
+      ".agents.defaults.models.\"${glmModel}\"".alias = "glm";
+      ".agents.defaults.models.\"${llamaModel}\"".alias = "llama";
     };
 
     memorySync = {


### PR DESCRIPTION
## What

Integrates local [Ollama](https://ollama.com) inference into OpenClaw via `configPatches` in `openclaw.nix`.

## Changes

- **Provider**: `http://localhost:11434` with native `ollama` API type
- **Models**:
  - `glm4` (GLM-4, 5.5 GB) — alias `/model glm`
  - `llama3.2` (Llama 3.2 3B, 2 GB) — alias `/model llama`
- Both models already pulled and tested locally

## Usage

```
/model glm    → switch to GLM-4 (local)
/model llama  → switch to Llama 3.2 (local)
/model sonnet → back to Claude Sonnet
```

## Notes

- Ollama systemd user service is already in `home/modules/ollama/default.nix`
- Run `systemctl --user start ollama` until next rebuild makes it persistent
- Zero cost, fully offline, no API key required