### PR TITLE
Remove silver from workpc openclaw grid (now a macbook Discord bot)

### DIFF
--- a/agents/skills/openclaw/scripts/read-agent-chat.sh
+++ b/agents/skills/openclaw/scripts/read-agent-chat.sh
@@ -6,82 +6,82 @@ readonly OPENCLAW_STATE_DIR="${HOME}/.openclaw"
 readonly AGENTS_DIR="${OPENCLAW_STATE_DIR}/agents"
 
 main() {
-  local agent_name=""
-  local session_id=""
-  local message_limit=50
-  local list_sessions=false
-  local show_tools=false
+	local agent_name=""
+	local session_id=""
+	local message_limit=50
+	local list_sessions=false
+	local show_tools=false
 
-  _parse_arguments "$@"
+	_parse_arguments "$@"
 
-  if [ -z "$agent_name" ]; then
-    _print_usage
-    exit 1
-  fi
+	if [ -z "$agent_name" ]; then
+		_print_usage
+		exit 1
+	fi
 
-  local sessions_dir="${AGENTS_DIR}/${agent_name}/sessions"
+	local sessions_dir="${AGENTS_DIR}/${agent_name}/sessions"
 
-  _ensure_agent_sessions_dir_exists "$sessions_dir" "$agent_name"
+	_ensure_agent_sessions_dir_exists "$sessions_dir" "$agent_name"
 
-  if [ "$list_sessions" = true ]; then
-    _list_agent_sessions "$sessions_dir"
-    return
-  fi
+	if [ "$list_sessions" = true ]; then
+		_list_agent_sessions "$sessions_dir"
+		return
+	fi
 
-  if [ -z "$session_id" ]; then
-    session_id="$(_resolve_latest_session_id "$sessions_dir")"
-  fi
+	if [ -z "$session_id" ]; then
+		session_id="$(_resolve_latest_session_id "$sessions_dir")"
+	fi
 
-  local session_file="${sessions_dir}/${session_id}.jsonl"
-  _ensure_session_file_exists "$session_file" "$session_id"
-  _render_chat_messages "$session_file" "$message_limit" "$show_tools"
+	local session_file="${sessions_dir}/${session_id}.jsonl"
+	_ensure_session_file_exists "$session_file" "$session_id"
+	_render_chat_messages "$session_file" "$message_limit" "$show_tools"
 }
 
 _parse_arguments() {
-  while [ $# -gt 0 ]; do
-    case "$1" in
-      --agent | -a)
-        agent_name="$2"
-        shift 2
-        ;;
-      --session | -s)
-        session_id="$2"
-        shift 2
-        ;;
-      --limit | -n)
-        message_limit="$2"
-        shift 2
-        ;;
-      --list | -l)
-        list_sessions=true
-        shift
-        ;;
-      --tools | -t)
-        show_tools=true
-        shift
-        ;;
-      --help | -h)
-        _print_usage
-        exit 0
-        ;;
-      *)
-        if [ -z "$agent_name" ]; then
-          agent_name="$1"
-        fi
-        shift
-        ;;
-    esac
-  done
+	while [ $# -gt 0 ]; do
+		case "$1" in
+		--agent | -a)
+			agent_name="$2"
+			shift 2
+			;;
+		--session | -s)
+			session_id="$2"
+			shift 2
+			;;
+		--limit | -n)
+			message_limit="$2"
+			shift 2
+			;;
+		--list | -l)
+			list_sessions=true
+			shift
+			;;
+		--tools | -t)
+			show_tools=true
+			shift
+			;;
+		--help | -h)
+			_print_usage
+			exit 0
+			;;
+		*)
+			if [ -z "$agent_name" ]; then
+				agent_name="$1"
+			fi
+			shift
+			;;
+		esac
+	done
 }
 
 _print_usage() {
-  cat >&2 <<'USAGE'
+	cat >&2 <<'USAGE'
 Usage: read-agent-chat.sh [OPTIONS] [AGENT_NAME]
 
 Read OpenClaw agent chat history from session JSONL files.
 
 Arguments:
-  AGENT_NAME              Agent name (e.g. silver, jenny, robson)
+  AGENT_NAME              Agent name (e.g. jenny, monster, robson)
 
 Options:
   -a, --agent NAME        Agent name (alternative to positional)
@@ -92,36 +92,36 @@ Options:
   -h, --help              Show this help
 
 Examples:
-  read-agent-chat.sh silver
-  read-agent-chat.sh --agent silver --limit 20
-  read-agent-chat.sh silver --list
-  read-agent-chat.sh silver --session bdf89bf8-5738-47c4-874a-d1389c64f603
-  read-agent-chat.sh silver --tools
+  read-agent-chat.sh jenny
+  read-agent-chat.sh --agent jenny --limit 20
+  read-agent-chat.sh jenny --list
+  read-agent-chat.sh jenny --session bdf89bf8-5738-47c4-874a-d1389c64f603
+  read-agent-chat.sh jenny --tools
 USAGE
 }
 
 _ensure_agent_sessions_dir_exists() {
-  local sessions_dir=$1
-  local agent_name=$2
+	local sessions_dir=$1
+	local agent_name=$2
 
-  if [ ! -d "$sessions_dir" ]; then
-    echo "Error: no sessions directory for agent '${agent_name}' at ${sessions_dir}" >&2
-    echo "Available agents:" >&2
-    ls "${AGENTS_DIR}" 2>/dev/null | sed 's/^/  /' >&2
-    exit 1
-  fi
+	if [ ! -d "$sessions_dir" ]; then
+		echo "Error: no sessions directory for agent '${agent_name}' at ${sessions_dir}" >&2
+		echo "Available agents:" >&2
+		ls "${AGENTS_DIR}" 2>/dev/null | sed 's/^/  /' >&2
+		exit 1
+	fi
 }
 
 _list_agent_sessions() {
-  local sessions_dir=$1
-  local sessions_json="${sessions_dir}/sessions.json"
+	local sessions_dir=$1
+	local sessions_json="${sessions_dir}/sessions.json"
 
-  if [ ! -f "$sessions_json" ]; then
-    echo "No sessions found." >&2
-    return
-  fi
+	if [ ! -f "$sessions_json" ]; then
+		echo "No sessions found." >&2
+		return
+	fi
 
-  jq -r '
+	jq -r '
     to_entries
     | map(select(.value.sessionId))
     | sort_by(-.value.updatedAt)
@@ -131,54 +131,54 @@ _list_agent_sessions() {
 }
 
 _resolve_latest_session_id() {
-  local sessions_dir=$1
-  local sessions_json="${sessions_dir}/sessions.json"
+	local sessions_dir=$1
+	local sessions_json="${sessions_dir}/sessions.json"
 
-  if [ ! -f "$sessions_json" ]; then
-    echo "Error: no sessions.json found in ${sessions_dir}" >&2
-    exit 1
-  fi
+	if [ ! -f "$sessions_json" ]; then
+		echo "Error: no sessions.json found in ${sessions_dir}" >&2
+		exit 1
+	fi
 
-  local latest_session_id
-  latest_session_id=$(jq -r '
+	local latest_session_id
+	latest_session_id=$(jq -r '
     to_entries
     | map(select(.value.sessionId))
     | sort_by(-.value.updatedAt)
     | .[0].value.sessionId // empty
   ' "$sessions_json")
 
-  if [ -z "$latest_session_id" ]; then
-    echo "Error: no sessions found for this agent" >&2
-    exit 1
-  fi
+	if [ -z "$latest_session_id" ]; then
+		echo "Error: no sessions found for this agent" >&2
+		exit 1
+	fi
 
-  echo "$latest_session_id"
+	echo "$latest_session_id"
 }
 
 _ensure_session_file_exists() {
-  local session_file=$1
-  local session_id=$2
+	local session_file=$1
+	local session_id=$2
 
-  if [ ! -f "$session_file" ]; then
-    echo "Error: session file not found: ${session_file}" >&2
-    exit 1
-  fi
+	if [ ! -f "$session_file" ]; then
+		echo "Error: session file not found: ${session_file}" >&2
+		exit 1
+	fi
 }
 
 _render_chat_messages() {
-  local session_file=$1
-  local message_limit=$2
-  local show_tools=$3
+	local session_file=$1
+	local message_limit=$2
+	local show_tools=$3
 
-  local jq_filter
+	local jq_filter
 
-  if [ "$show_tools" = true ]; then
-    jq_filter='select(.type == "message")'
-  else
-    jq_filter='select(.type == "message" and (.message.role == "user" or .message.role == "assistant"))'
-  fi
+	if [ "$show_tools" = true ]; then
+		jq_filter='select(.type == "message")'
+	else
+		jq_filter='select(.type == "message" and (.message.role == "user" or .message.role == "assistant"))'
+	fi
 
-  jq -r "$jq_filter"' |
+	jq -r "$jq_filter"' |
     .timestamp as $ts |
     .message |
     (

--- a/agents/skills/personal/openclaw-grid.md
+++ b/agents/skills/personal/openclaw-grid.md
@@ -5,7 +5,7 @@
 | **clever** | Default agent, street-smart | claude-opus | Quick responses, general tasks, user-facing chat |
 | **golden** | Specialist | claude-sonnet | Cost-effective, good for bulk tasks, coding, analysis |
 
-This list reflects the current NixOS grid. The work PC grid has: robson, jenny, monster, silver.
+This list reflects the current NixOS grid. The work PC grid has: robson, jenny, monster.
 </team>
 
 <communication>

--- a/home/modules/openclaw/tests/nix-config-checks.nix
+++ b/home/modules/openclaw/tests/nix-config-checks.nix
@@ -56,9 +56,8 @@ let
             hasInList workpcEnabledAgents "robson"
             && hasInList workpcEnabledAgents "jenny"
             && hasInList workpcEnabledAgents "monster"
-            && hasInList workpcEnabledAgents "silver"
           )
-          "workpc should have robson jenny monster silver, got: ${builtins.concatStringsSep ", " workpcEnabledAgents}";
+          "workpc should have robson jenny monster, got: ${builtins.concatStringsSep ", " workpcEnabledAgents}";
 
       oc-workpc-default-agent = mkEvalCheck "oc-workpc-default-agent" (
         workpcOc.defaultAgent == "robson"
@@ -76,8 +75,7 @@ let
         hasInList workpcAgentListIds "robson"
         && hasInList workpcAgentListIds "jenny"
         && hasInList workpcAgentListIds "monster"
-        && hasInList workpcAgentListIds "silver"
-      ) "agents list should include robson jenny monster silver";
+      ) "agents list should include robson jenny monster";
 
       oc-workpc-agents-list-robson-default =
         let
@@ -102,8 +100,7 @@ let
         hasInList workpcConfigPatchKeys ".channels.telegram.accounts.robson"
         && hasInList workpcConfigPatchKeys ".channels.telegram.accounts.jenny"
         && hasInList workpcConfigPatchKeys ".channels.telegram.accounts.monster"
-        && hasInList workpcConfigPatchKeys ".channels.telegram.accounts.silver"
-      ) "workpc should have telegram accounts for robson jenny monster silver";
+      ) "workpc should have telegram accounts for robson jenny monster";
 
       oc-workpc-no-jarvis-telegram = mkEvalCheck "oc-workpc-no-jarvis-telegram" (
         !(hasInList workpcConfigPatchKeys ".channels.telegram.accounts.jarvis")
@@ -113,8 +110,7 @@ let
         hasInList workpcBindingAgentIds "robson"
         && hasInList workpcBindingAgentIds "jenny"
         && hasInList workpcBindingAgentIds "monster"
-        && hasInList workpcBindingAgentIds "silver"
-      ) "workpc bindings should include robson jenny monster silver";
+      ) "workpc bindings should include robson jenny monster";
 
       oc-workpc-no-jarvis-binding = mkEvalCheck "oc-workpc-no-jarvis-binding" (
         !(hasInList workpcBindingAgentIds "jarvis")
@@ -153,7 +149,6 @@ let
         hasInList workpcSecretPatchKeys ".channels.telegram.accounts.robson.botToken"
         && hasInList workpcSecretPatchKeys ".channels.telegram.accounts.jenny.botToken"
         && hasInList workpcSecretPatchKeys ".channels.telegram.accounts.monster.botToken"
-        && hasInList workpcSecretPatchKeys ".channels.telegram.accounts.silver.botToken"
       ) "workpc should have telegram bot token secrets for enabled agents";
 
       oc-workpc-no-jarvis-bot-token = mkEvalCheck "oc-workpc-no-jarvis-bot-token" (
@@ -235,7 +230,6 @@ let
         hasInList workpcOc.memorySync.agents "robson"
         && hasInList workpcOc.memorySync.agents "jenny"
         && hasInList workpcOc.memorySync.agents "monster"
-        && hasInList workpcOc.memorySync.agents "silver"
       ) "memory sync should be configured for local agents";
 
       oc-workpc-memory-sync-remote-host = mkEvalCheck "oc-workpc-memory-sync-remote-host" (
@@ -258,10 +252,6 @@ let
       oc-agent-model-primary-set = mkEvalCheck "oc-agent-model-primary-set" (
         workpcOc.agents.robson.model.primary != null && workpcOc.agents.robson.model.primary != ""
       ) "robson model.primary should be set";
-
-      oc-agent-silver-cheaper-model = mkEvalCheck "oc-agent-silver-cheaper-model" (
-        workpcOc.agents.silver.model.primary == "openai-codex/gpt-5.3-codex"
-      ) "silver should use cheaper model, got ${workpcOc.agents.silver.model.primary}";
 
       oc-agent-default-tts-engine = mkEvalCheck "oc-agent-default-tts-engine" (
         workpcOc.agents.robson.tts.engine == "edge-tts"
@@ -313,8 +303,7 @@ let
         hasInList workpcConfigPatches.".tools.agentToAgent.allow" "robson"
         && hasInList workpcConfigPatches.".tools.agentToAgent.allow" "jenny"
         && hasInList workpcConfigPatches.".tools.agentToAgent.allow" "monster"
-        && hasInList workpcConfigPatches.".tools.agentToAgent.allow" "silver"
-      ) "workpc agentToAgent allow list should include robson jenny monster silver";
+      ) "workpc agentToAgent allow list should include robson jenny monster";
 
       oc-workpc-sessions-visibility = mkEvalCheck "oc-workpc-sessions-visibility" (
         workpcConfigPatches.".tools.sessions.visibility" == "all"


### PR DESCRIPTION
Silver has been repurposed as a Discord-only bot on the macbook (separate dotfiles repo, lucas.zanoni/.dotfiles). This PR removes silver from the public workpc openclaw wiring so workpc rebuilds stop expecting silver as an active agent.

## Changes

- `home/modules/openclaw/tests/nix-config-checks.nix` - drop silver from enabledAgents, agents.list, telegram.accounts, bindings, memorySync.agents, and agentToAgent.allow assertions; remove the dedicated `oc-agent-silver-cheaper-model` check.
- `agents/skills/personal/openclaw-grid.md` - drop silver from the workpc grid roster.
- `agents/skills/openclaw/scripts/read-agent-chat.sh` - replace silver with jenny in the usage examples (silver agent sessions no longer exist on workpc).

## Not changed (intentionally)

- `secrets/secrets.nix` and `home/modules/security/agenix.nix` still list `bot-tokens/discord-bot-token-silver.age` and `bot-tokens/telegram-bot-token-silver.age` so the encrypted tokens remain available if needed.
- The actual silver agent definition lives in the private-config submodule. After this PR is merged, the matching entry in private-config also needs to be removed (or kept dormant) so the merged workpc config no longer enables silver as an openclaw agent.

## Verification

After merging, on workpc:
```
nix flake check
```
should pass without silver-related failures (the assertions are gone). Until private-config also drops silver, the merged config will still define silver - this just stops the public test layer from gating on it.