### PR TITLE
feat(clawde): consolidate agent workspaces under ~/clawde/ + scope daily-report skill to PM workspaces

### DIFF
--- a/home/base/claude/README.md
+++ b/home/base/claude/README.md
@@ -25,7 +25,7 @@ Home-manager module that installs Claude Code, declares its config, and runs per
 
 ## clawde
 
-`clawde/` is the persistent-agent framework. One systemd-user service supervises one tmux session (`claude-discord`), with one window per agent. Each agent is declared as `clawde.agents.<name>` with a channel adapter (`channel.type = "pm"` or `"discord"`) and optional peer adapters (`expose.a2a.enable = true`).
+`clawde/` is the persistent-agent framework. One systemd-user service supervises one tmux session (`clawde`), with one window per agent. Each agent is declared as `clawde.agents.<name>` with a channel adapter (`channel.type = "pm"` or `"discord"`) and optional peer adapters (`expose.a2a.enable = true`).
 
 See `clawde/default.nix` for the option schema, `clawde/instructions/clawde-runtime.md` for runtime rules, and `clawde/channel-adapters/<name>/instructions/<name>-runtime.md` for per-channel behavior.
 

--- a/home/base/claude/agents/jojo-clawde-agents.nix
+++ b/home/base/claude/agents/jojo-clawde-agents.nix
@@ -76,7 +76,7 @@ in
         - Use the codex MCP (mcp__codex__*) for tasks that fit Codex's strengths.
 
         Persistent project agents:
-        - Each project with a .pm/HEARTBEAT.md has a tmux window inside the claude-discord tmux session. Send work to it with tmux send-keys against that window.
+        - Each project with a .pm/HEARTBEAT.md has a tmux window inside the clawde tmux session. Send work to it with tmux send-keys against that window.
         - Persistent agents are declared in nix (home/base/claude/agents/jojo-clawde-agents.nix). If a project does not have one yet, ask Lucas to declare it.
 
         When delegating, write a tight self-contained brief. The receiving session does not see your Discord conversation.

--- a/home/base/claude/clawde/lib.nix
+++ b/home/base/claude/clawde/lib.nix
@@ -10,7 +10,7 @@ let
   secretsDirectory = "${homeDir}/.secrets";
   claudeBinary = lib.getExe config.claude.package;
 
-  tmuxSessionName = "claude-discord";
+  tmuxSessionName = "clawde";
   agentWorkspacesBaseDirectory = "${homeDir}/.claude-discord-agents";
 
   cfg = config.clawde;

--- a/home/base/claude/clawde/lib.nix
+++ b/home/base/claude/clawde/lib.nix
@@ -125,6 +125,7 @@ let
   buildAgentWindowCommand =
     name: agent:
     let
+      workspaceDirectory = agentWorkspaceDirectory name;
       heartbeatBootstrapArgvFlag =
         if agent.heartbeatInterval != null then
           "--heartbeat-bootstrap-argv ${lib.escapeShellArg (builtins.toJSON (buildHeartbeatBootstrapArgv name agent))}"
@@ -136,9 +137,7 @@ let
         else
           "";
       dailySessionRotationFlag = if agent.dailySessionRotation then "--daily-session-rotation" else "";
-    in
-    pkgs.writeShellScript "clawde-agent-${name}" (
-      lib.concatStringsSep " " [
+      execPythonWrapperInvocation = lib.concatStringsSep " " [
         "exec"
         "${pkgs.python312}/bin/python3"
         "${./scripts/clawde-agent-wrapper.py}"
@@ -147,8 +146,12 @@ let
         heartbeatBootstrapArgvFlag
         activeHoursFlags
         dailySessionRotationFlag
-      ]
-    );
+      ];
+    in
+    pkgs.writeShellScript "clawde-agent-${name}" ''
+      cd ${lib.escapeShellArg workspaceDirectory}
+      ${execPythonWrapperInvocation}
+    '';
 
   buildAgentSpecification = name: agent: {
     inherit name;

--- a/home/base/claude/clawde/lib.nix
+++ b/home/base/claude/clawde/lib.nix
@@ -155,7 +155,7 @@ let
 
   buildAgentSpecification = name: agent: {
     inherit name;
-    wrapper_command = "${buildAgentWindowCommand name agent}";
+    wrapper_command = "exec ${buildAgentWindowCommand name agent}";
   };
 
   buildAllSpecificationsForOneAgent =

--- a/home/base/claude/clawde/lib.nix
+++ b/home/base/claude/clawde/lib.nix
@@ -8,7 +8,7 @@ let
 
   homeDir = homeDirectory;
   secretsDirectory = "${homeDir}/.secrets";
-  claudeBinary = "${homeDir}/.nix-profile/bin/claude";
+  claudeBinary = lib.getExe config.claude.package;
 
   tmuxSessionName = "claude-discord";
   agentWorkspacesBaseDirectory = "${homeDir}/.claude-discord-agents";

--- a/home/base/claude/docs/scrollback.md
+++ b/home/base/claude/docs/scrollback.md
@@ -16,7 +16,7 @@ Layer 3 is the `prefix t` toggle, which opens a maximized side pane running the 
 
 ## Past Sessions
 
-Tmux scrollback only ever holds the current pane's lifetime. Conversations from yesterday, from another window, or from any clawde agent running in the `claude-discord` session are completely outside its reach. The session jsonl files under `~/.claude/projects/<encoded-cwd>/` are the only durable record. `claude-show-session` reads the latest one for the current cwd; `claude --resume <uuid>` reloads the conversation into a live UI. Both bypass tmux scrollback entirely.
+Tmux scrollback only ever holds the current pane's lifetime. Conversations from yesterday, from another window, or from any clawde agent running in the `clawde` session are completely outside its reach. The session jsonl files under `~/.claude/projects/<encoded-cwd>/` are the only durable record. `claude-show-session` reads the latest one for the current cwd; `claude --resume <uuid>` reloads the conversation into a live UI. Both bypass tmux scrollback entirely.
 
 ## Tmux Configuration That Matters
 


### PR DESCRIPTION
## Summary

Two intertwined refactors:

1. **`~/clawde/` is now the canonical persistent-worktree base for every clawde-managed agent**, replacing the ad-hoc `~/.claude-discord-agents/` (discord agents) and `~/repo/<name>/` (PM agents) split. coates-pm moved from `~/repo/coates-pm/` to `~/clawde/coates-pm/`; silver, a2a-test-alpha, a2a-test-beta migrated from `~/.claude-discord-agents/` to `~/clawde/`. The default in `clawde/lib.nix:agentWorkspacesBaseDirectory` now points at `~/clawde`, so PM agents declared without an explicit `channel.pm.projectDirectory` land at `~/clawde/<name>` automatically.

2. **The `daily-report` skill is now PM-workspace-aware**. Reports were always written to a global `~/vault/manager-reports/` regardless of where Claude was invoked. They now write to `<pm-workspace-root>/manager-reports/` (top-level inside the workspace), with the root discovered by walking up from cwd for a `.pm/HEARTBEAT.md` marker. The skill errors out instead of falling back to a vault when no marker is found, so misplaced report files cannot silently scatter.

## Why the rebuild script changed

`hosts/{rin,kira}/rebuild/rebuild` used a bare `${DOTFILES_DIRECTORY}#<host>` flake reference. Nix flakes copy the source tree to /nix/store without git-submodule contents by default, so `private-config/machines/<host>/clawde-pm.nix` resolved to an empty directory at evaluation time and the PM agent declaration silently dropped out of the clawde service spec. Switching to `git+file://...?submodules=1#<host>` pulls submodule contents into the flake ingestion, so private-config-declared agents actually land in the eval.

## Side-effects worth noting

- The `agentWorkspacesBaseDirectory` rename touched a handful of docstrings (`clawde/interfaces.nix`, `clawde/options.nix`), one helper comment (`clawde/scripts/seed-memory-bridge.sh`), the memory architecture doc, and two encoding-test fixtures that used the old path as their realistic example.
- Existing manager reports were migrated from `~/vault/manager-reports/` to `~/clawde/coates-pm/manager-reports/` so the day-archive carries over.
- Includes one unrelated commit (`e66201f2 feat(aerospace)`) for the unstable aerospace pin that was in-flight in parallel.

## Verified post-rebuild

- `nix eval --impure 'git+file://...?submodules=1#darwinConfigurations.rin...clawde.agents'` returns `[coates-pm silver]`
- Live clawde service spec contains both agents
- Both wrapper processes show correct cwd: `/Users/lucas.zanoni/clawde/{coates-pm,silver}`
- Skill helper resolves reports to `~/clawde/coates-pm/manager-reports/` from inside that workspace and errors out from `/tmp/`
- `tests/run.sh --nix` passes